### PR TITLE
Do not break Action when using schedule jobs

### DIFF
--- a/create-pull-request.py
+++ b/create-pull-request.py
@@ -15,6 +15,10 @@ def get_github_event(github_event_path):
 
 
 def ignore_event(github_event):
+    if 'schedule' in github_event:
+        print("Allow schedule event.")
+        return False
+        
     # Ignore push events on deleted branches
     # The event we want to ignore occurs when a PR is created but the repository owner decides
     # not to commit the changes. They close the PR and delete the branch. This creates a 
@@ -39,8 +43,12 @@ def pr_branch_exists(repo, branch):
 
 
 def get_head_author(github_event):
-    email = "{head_commit[author][email]}".format(**github_event)
-    name = "{head_commit[author][name]}".format(**github_event)
+    if 'schedule' in github_event:
+        email=os.environ['GITHUB_ACTOR']
+        name=os.environ['GITHUB_ACTOR'] + '@users.noreply.github.com'
+    else 
+        email = "{head_commit[author][email]}".format(**github_event)
+        name = "{head_commit[author][name]}".format(**github_event)
     return email, name
 
 


### PR DESCRIPTION
As outline in #29, using a scheduled workflow breaks this Action with 

```
Traceback (most recent call last):
  File "/create-pull-request.py", line 119, in <module>
     if not ignore_event(github_event):
  File "/create-pull-request.py", line 23, in ignore_event
    deleted = "{deleted}".format(**github_event)

KeyError: 'deleted'
##[error]Docker run failed with exit code 1
```

The issue seems to be related to the fact, that on scheduled jobs the `$GITHUB_EVENT_PATH` file contains just one attribute 

```json
{
  "schedule": "* * * * *"
}
```

whereas on `push` it contains a proper GitHub payload with `repository` and `sender` details.


I'm not really experienced with Python to provide a proper bug fix, but maybe @peter-evans can help me landing this fix. From what I can tell it's this [ignore_event function](https://github.com/peter-evans/create-pull-request/blob/facb42d77609ff5c9b181a506486ee31c2a425f8/create-pull-request.py#L17-L31) which needs a `deleted` along with a `ref` key in that json.

