### PR TITLE
Add skip_ignore arg to ignore_event function

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ These variables are all optional. If not set, a default value will be used.
 - `COMMIT_MESSAGE` - The message to use when committing changes.
 - `PULL_REQUEST_TITLE` - The title of the pull request.
 - `PULL_REQUEST_BODY` - The body of the pull request.
+- `SKIP_IGNORE` - If present, the `ignore_event` function will not run
 
 #### Branch naming
 
@@ -52,7 +53,7 @@ If there are files or directories you want to ignore you can simply add them to 
 
 ## Example
 
-Here is an example that sets all the environment variables.
+Here is an example that sets all the environment variables (except `SKIP_IGNORE`).
 
 ```yml
     - name: Create Pull Request

--- a/create-pull-request.py
+++ b/create-pull-request.py
@@ -15,8 +15,8 @@ def get_github_event(github_event_path):
     return github_event
 
 
-def ignore_event(event_name, event_data):
-    if event_name == "push":
+def ignore_event(event_name, event_data, skip_ignore):
+    if event_name == "push" and not skip_ignore:
         # Ignore push events on deleted branches
         # The event we want to ignore occurs when a PR is created but the repository owner decides
         # not to commit the changes. They close the PR and delete the branch. This creates a 
@@ -122,7 +122,8 @@ def process_event(event_name, event_data, repo, branch, base):
 event_name = os.environ['GITHUB_EVENT_NAME']
 event_data = get_github_event(os.environ['GITHUB_EVENT_PATH'])
 # Check if this event should be ignored
-if not ignore_event(event_name, event_data):
+skip_ignore_event = bool(os.environ.get('SKIP_IGNORE'))
+if not ignore_event(event_name, event_data, skip_ignore_event):
     # Set the repo to the working directory
     repo = Repo(os.getcwd())
 


### PR DESCRIPTION
During testing, I found it useful to have this function skipped so I added a simple check for `SKIP_IGNORE` env variable. If present, the `ignore_event` function auto passes. This shouldn't have any impact on current workloads (unless `SKIP_IGNORE` is being populated and used in the same job step inadvertently).