### PR TITLE
Add possibility to alter the target repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ See [this issue](https://github.com/peter-evans/create-pull-request/issues/48) f
 | Name | Description | Default |
 | --- | --- | --- |
 | `token` | `GITHUB_TOKEN` or a `repo` scoped [PAT](https://help.github.com/en/github/authenticating-to-github/creating-a-personal-access-token-for-the-command-line). | |
+| `repository` | The repository where the pull request will be created. | `$GITHUB_REPOSITORY` |
 | `path` | Relative path under `$GITHUB_WORKSPACE` to the repository. | `$GITHUB_WORKSPACE` |
 | `commit-message` | The message to use when committing changes. | `[create-pull-request] automated change` |
 | `committer` | The committer name and email address in the format `Display Name <email@address.com>`. | Defaults to the GitHub Actions bot user. See [Committer and author](#committer-and-author) for details. |

--- a/action.yml
+++ b/action.yml
@@ -6,6 +6,8 @@ inputs:
     required: true
   path:
     description: 'Relative path under $GITHUB_WORKSPACE to the repository.'
+  repository:
+    description: 'The repository where the pull request will be created'
   commit-message:
     description: 'The message to use when committing changes.'
   committer:

--- a/dist/index.js
+++ b/dist/index.js
@@ -1027,6 +1027,7 @@ async function run() {
     const inputs = {
       token: core.getInput("token"),
       path: core.getInput("path"),
+      repository: core.getInput("repository"),
       commitMessage: core.getInput("commit-message"),
       committer: core.getInput("committer"),
       author: core.getInput("author"),
@@ -1047,6 +1048,7 @@ async function run() {
 
     // Set environment variables from inputs.
     if (inputs.token) process.env.GITHUB_TOKEN = inputs.token;
+    if (inputs.repository) process.env.CPR_REPOSITORY = inputs.repository;
     if (inputs.path) process.env.CPR_PATH = inputs.path;
     if (inputs.commitMessage) process.env.CPR_COMMIT_MESSAGE = inputs.commitMessage;
     if (inputs.committer) process.env.CPR_COMMITTER = inputs.committer;

--- a/dist/src/create_pull_request.py
+++ b/dist/src/create_pull_request.py
@@ -22,6 +22,7 @@ DEFAULT_BODY = (
     + "[create-pull-request](https://github.com/peter-evans/create-pull-request) GitHub action"
 )
 DEFAULT_BRANCH = "create-pull-request/patch"
+DEFAULT_REPOSITORY = os.environ["GITHUB_REPOSITORY"]
 
 
 def get_git_config_value(repo, name):
@@ -94,7 +95,7 @@ def set_committer_author(repo, committer, author):
 
 # Get required environment variables
 github_token = os.environ["GITHUB_TOKEN"]
-github_repository = os.environ["GITHUB_REPOSITORY"]
+github_repository = os.getenv("CPR_REPOSITORY", DEFAULT_REPOSITORY)
 # Get environment variables with defaults
 path = os.getenv("CPR_PATH", os.getcwd())
 branch = os.getenv("CPR_BRANCH", DEFAULT_BRANCH)

--- a/index.js
+++ b/index.js
@@ -25,6 +25,7 @@ async function run() {
     const inputs = {
       token: core.getInput("token"),
       path: core.getInput("path"),
+      repository: core.getInput("repository"),
       commitMessage: core.getInput("commit-message"),
       committer: core.getInput("committer"),
       author: core.getInput("author"),
@@ -45,6 +46,7 @@ async function run() {
 
     // Set environment variables from inputs.
     if (inputs.token) process.env.GITHUB_TOKEN = inputs.token;
+    if (inputs.repository) process.env.CPR_REPOSITORY = inputs.repository;
     if (inputs.path) process.env.CPR_PATH = inputs.path;
     if (inputs.commitMessage) process.env.CPR_COMMIT_MESSAGE = inputs.commitMessage;
     if (inputs.committer) process.env.CPR_COMMITTER = inputs.committer;

--- a/src/create_pull_request.py
+++ b/src/create_pull_request.py
@@ -22,6 +22,7 @@ DEFAULT_BODY = (
     + "[create-pull-request](https://github.com/peter-evans/create-pull-request) GitHub action"
 )
 DEFAULT_BRANCH = "create-pull-request/patch"
+DEFAULT_REPOSITORY = os.environ["GITHUB_REPOSITORY"]
 
 
 def get_git_config_value(repo, name):
@@ -94,7 +95,7 @@ def set_committer_author(repo, committer, author):
 
 # Get required environment variables
 github_token = os.environ["GITHUB_TOKEN"]
-github_repository = os.environ["GITHUB_REPOSITORY"]
+github_repository = os.getenv("CPR_REPOSITORY", DEFAULT_REPOSITORY)
 # Get environment variables with defaults
 path = os.getenv("CPR_PATH", os.getcwd())
 branch = os.getenv("CPR_BRANCH", DEFAULT_BRANCH)


### PR DESCRIPTION
# What does this PR do?

Adds a new configuration variable `repository` which allows altering the destination repository in case the action wants to be used to create a PR to a remote repository, different to the one launching the workflow. 

This new variable defaults to the old value `GITHUB_REPOSITORY` environment variable.

# Related issues

This closes #105 