### PR TITLE
Allow custom repository when pushin in fork

### DIFF
--- a/.github/workflows/cpr-example-command.yml
+++ b/.github/workflows/cpr-example-command.yml
@@ -30,6 +30,7 @@ jobs:
           project: Example Project
           project-column: To do
           branch: example-patches
+          request-to-parent: false
       - name: Check outputs
         run: |
           echo "Pull Request Number - ${{ env.PULL_REQUEST_NUMBER }}"

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ With the exception of `token`, all inputs are **optional**. If not set, sensible
 | `project` | The name of the project for which a card should be created. Requires `project-column`. | |
 | `project-column` | The name of the project column under which a card should be created. Requires `project`. | |
 | `branch` | The branch name. See [Branch naming](#branch-naming) for details. | `create-pull-request/patch` |
+| `request-to-parent` | Whether or not the pull request should be create on the parent repository. | `false` |
 | `base` | Sets the pull request base branch. | Defaults to the branch checked out in the workflow. |
 | `branch-suffix` | The branch suffix type. Valid values are `random`, `timestamp` and `short-commit-hash`. See [Branch naming](#branch-naming) for details. | |
 
@@ -186,6 +187,7 @@ jobs:
           project: Example Project
           project-column: To do
           branch: example-patches
+          request-to-parent: false
       - name: Check outputs
         run: |
           echo "Pull Request Number - ${{ env.PULL_REQUEST_NUMBER }}"

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ With the exception of `token`, all inputs are **optional**. If not set, sensible
 | `project` | The name of the project for which a card should be created. Requires `project-column`. | |
 | `project-column` | The name of the project column under which a card should be created. Requires `project`. | |
 | `branch` | The branch name. See [Branch naming](#branch-naming) for details. | `create-pull-request/patch` |
-| `request-to-parent` | Whether or not the pull request should be create on the parent repository. | `false` |
+| `request-to-parent` | Create the pull request in the parent repository of the checked out fork. | `false` |
 | `base` | Sets the pull request base branch. | Defaults to the branch checked out in the workflow. |
 | `branch-suffix` | The branch suffix type. Valid values are `random`, `timestamp` and `short-commit-hash`. See [Branch naming](#branch-naming) for details. | |
 

--- a/action.yml
+++ b/action.yml
@@ -32,6 +32,9 @@ inputs:
     description: 'The name of the project column under which a card should be created.'
   branch:
     description: 'The pull request branch name.'
+  request-to-parent:
+    description: 'Whether or not the pull request should be create on the parent repository.'
+    default: false
   base:
     description: 'The pull request base branch.'
   branch-suffix:
@@ -43,5 +46,5 @@ runs:
   using: 'node12'
   main: 'dist/index.js'
 branding:
-  icon: 'git-pull-request'  
+  icon: 'git-pull-request'
   color: 'gray-dark'

--- a/action.yml
+++ b/action.yml
@@ -33,7 +33,7 @@ inputs:
   branch:
     description: 'The pull request branch name.'
   request-to-parent:
-    description: 'Whether or not the pull request should be create on the parent repository.'
+    description: 'Create the pull request in the parent repository of the checked out fork.'
     default: false
   base:
     description: 'The pull request base branch.'

--- a/dist/cpr/create_or_update_pull_request.py
+++ b/dist/cpr/create_or_update_pull_request.py
@@ -67,7 +67,7 @@ def create_or_update_pull_request(
     if request_to_parent:
         github_repo = github_repo.parent
         if github_repo is None:
-            raise ValueError("The repository is not a fork. The parameter request-to-parent should be set to false.")
+            raise ValueError("The checked out repository is not a fork. Input 'request-to-parent' should be set to false.")
 
     head_branch = f"{head_repo.owner.login}:{branch}"
 

--- a/dist/cpr/create_or_update_pull_request.py
+++ b/dist/cpr/create_or_update_pull_request.py
@@ -56,25 +56,37 @@ def create_or_update_pull_request(
     team_reviewers,
     project_name,
     project_column_name,
+    request_to_parent,
 ):
+    if request_to_parent is None:
+        request_to_parent = False
+    else:
+        request_to_parent = request_to_parent.lower() in ['true', '1', 't', 'y', 'yes', 'on']
+
+    github_repo = head_repo = Github(github_token).get_repo(github_repository)
+    if request_to_parent:
+        github_repo = github_repo.parent
+        if github_repo is None:
+            raise ValueError("The repository is not a fork. The parameter request-to-parent should be set to false.")
+
+    head_branch = f"{head_repo.owner.login}:{branch}"
+
     # Create the pull request
-    github_repo = Github(github_token).get_repo(github_repository)
     try:
         pull_request = github_repo.create_pull(
-            title=title, body=body, base=base, head=branch
+            title=title, body=body, base=base, head=head_branch
         )
-        print(f"Created pull request #{pull_request.number} ({branch} => {base})")
+        print(f"Created pull request #{pull_request.number} ({head_branch} => {github_repo.owner.login}:{base})")
     except GithubException as e:
         if e.status == 422:
             # A pull request exists for this branch and base
-            head_branch = "{}:{}".format(github_repository.split("/")[0], branch)
             # Get the pull request
             pull_request = github_repo.get_pulls(
                 state="open", base=base, head=head_branch
             )[0]
             # Update title and body
             pull_request.as_issue().edit(title=title, body=body)
-            print(f"Updated pull request #{pull_request.number} ({branch} => {base})")
+            print(f"Updated pull request #{pull_request.number} ({head_branch} => {github_repo.owner.login}:{base})")
         else:
             print(str(e))
             raise

--- a/dist/cpr/create_pull_request.py
+++ b/dist/cpr/create_pull_request.py
@@ -224,4 +224,5 @@ if result["action"] in ["created", "updated"]:
         os.environ.get("CPR_TEAM_REVIEWERS"),
         os.environ.get("CPR_PROJECT_NAME"),
         os.environ.get("CPR_PROJECT_COLUMN_NAME"),
+        os.environ.get("CPR_REQUEST_TO_PARENT"),
     )

--- a/dist/index.js
+++ b/dist/index.js
@@ -4275,6 +4275,7 @@ async function run() {
       project: core.getInput("project"),
       projectColumn: core.getInput("project-column"),
       branch: core.getInput("branch"),
+      request_to_parent: core.getInput("request-to-parent"),
       base: core.getInput("base"),
       branchSuffix: core.getInput("branch-suffix")
     };
@@ -4296,6 +4297,7 @@ async function run() {
     if (inputs.project) process.env.CPR_PROJECT_NAME = inputs.project;
     if (inputs.projectColumn) process.env.CPR_PROJECT_COLUMN_NAME = inputs.projectColumn;
     if (inputs.branch) process.env.CPR_BRANCH = inputs.branch;
+    if (inputs.request_to_parent) process.env.CPR_REQUEST_TO_PARENT = inputs.request_to_parent;
     if (inputs.base) process.env.CPR_BASE = inputs.base;
     if (inputs.branchSuffix) process.env.CPR_BRANCH_SUFFIX = inputs.branchSuffix;
 

--- a/docs/concepts-guidelines.md
+++ b/docs/concepts-guidelines.md
@@ -180,7 +180,7 @@ How to use SSH (deploy keys) with create-pull-request action:
           token: ${{ secrets.GITHUB_TOKEN }}
 ```
 
-### Push in fork
+### Push pull request branches to a fork
 
 To enforce security, you can use a dedicated user using [machine account](https://help.github.com/en/github/site-policy/github-terms-of-service#3-account-requirements).
 This user has no access to the main repository, it will use their own fork to push code and create the pull request.
@@ -190,7 +190,7 @@ This user has no access to the main repository, it will use their own fork to pu
 3. create a [Personal Access Token (PAT)](https://help.github.com/en/github/authenticating-to-github/creating-a-personal-access-token-for-the-command-line).
 4. logout and go back to your main user.
 5. Add a secret to the repository containing the above PAT.
-6. As show in the example below, switch the git remote to the fork's url after checkout and set the option `request-on-parent`
+6. As shown in the example below, switch the git remote to the fork's url after checkout and set the action input `request-on-parent` to `true`.
 
 ```yaml
       - uses: actions/checkout@v2

--- a/docs/concepts-guidelines.md
+++ b/docs/concepts-guidelines.md
@@ -13,6 +13,7 @@ This document covers terminology, how the action works, general usage guidelines
 - [Advanced usage](#advanced-usage)
   - [Creating pull requests in a remote repository](#creating-pull-requests-in-a-remote-repository)
   - [Push using SSH (deploy keys)](#push-using-ssh-deploy-keys)
+  - [Push pull request branches to a fork](#push-pull-request-branches-to-a-fork)
   - [Running in a container](#running-in-a-container)
   - [Creating pull requests on tag push](#creating-pull-requests-on-tag-push)
 

--- a/docs/concepts-guidelines.md
+++ b/docs/concepts-guidelines.md
@@ -180,6 +180,34 @@ How to use SSH (deploy keys) with create-pull-request action:
           token: ${{ secrets.GITHUB_TOKEN }}
 ```
 
+### Push in fork
+
+To enforce security, you can use a dedicated user using [machine account](https://help.github.com/en/github/site-policy/github-terms-of-service#3-account-requirements).
+This user has no access to the main repository, it will use their own fork to push code and create the pull request.
+
+1. Create a new github user, then login with this user.
+2. fork the repository.
+3. create a [Personal Access Token (PAT)](https://help.github.com/en/github/authenticating-to-github/creating-a-personal-access-token-for-the-command-line).
+4. logout and go back to your main user.
+5. Add a secret to the repository containing the above PAT.
+6. As show in the example bellow, switch the git remote to the fork's url after checkout and set the option `request-on-parent`
+
+```yaml
+      - uses: actions/checkout@v2
+
+      - run: |
+          git config user.password ${{ secrets.PAT }}
+          git remote set-url origin https://github.com/bot-user/fork-project
+          git fetch --unshallow -p origin
+
+      # Make changes to pull request here
+
+      - uses: peter-evans/create-pull-request@v2
+        with:
+          token: ${{ secrets.PAT }}
+          request-on-parent: true
+```
+
 ### Running in a container
 
 This action can be run inside a container by installing the action's dependencies either in the Docker image itself, or during the workflow.

--- a/docs/concepts-guidelines.md
+++ b/docs/concepts-guidelines.md
@@ -190,7 +190,7 @@ This user has no access to the main repository, it will use their own fork to pu
 3. create a [Personal Access Token (PAT)](https://help.github.com/en/github/authenticating-to-github/creating-a-personal-access-token-for-the-command-line).
 4. logout and go back to your main user.
 5. Add a secret to the repository containing the above PAT.
-6. As show in the example bellow, switch the git remote to the fork's url after checkout and set the option `request-on-parent`
+6. As show in the example below, switch the git remote to the fork's url after checkout and set the option `request-on-parent`
 
 ```yaml
       - uses: actions/checkout@v2

--- a/src/cpr/create_or_update_pull_request.py
+++ b/src/cpr/create_or_update_pull_request.py
@@ -67,7 +67,7 @@ def create_or_update_pull_request(
     if request_to_parent:
         github_repo = github_repo.parent
         if github_repo is None:
-            raise ValueError("The repository is not a fork. The parameter request-to-parent should be set to false.")
+            raise ValueError("The checked out repository is not a fork. Input 'request-to-parent' should be set to false.")
 
     head_branch = f"{head_repo.owner.login}:{branch}"
 

--- a/src/cpr/create_or_update_pull_request.py
+++ b/src/cpr/create_or_update_pull_request.py
@@ -56,25 +56,37 @@ def create_or_update_pull_request(
     team_reviewers,
     project_name,
     project_column_name,
+    request_to_parent,
 ):
+    if request_to_parent is None:
+        request_to_parent = False
+    else:
+        request_to_parent = request_to_parent.lower() in ['true', '1', 't', 'y', 'yes', 'on']
+
+    github_repo = head_repo = Github(github_token).get_repo(github_repository)
+    if request_to_parent:
+        github_repo = github_repo.parent
+        if github_repo is None:
+            raise ValueError("The repository is not a fork. The parameter request-to-parent should be set to false.")
+
+    head_branch = f"{head_repo.owner.login}:{branch}"
+
     # Create the pull request
-    github_repo = Github(github_token).get_repo(github_repository)
     try:
         pull_request = github_repo.create_pull(
-            title=title, body=body, base=base, head=branch
+            title=title, body=body, base=base, head=head_branch
         )
-        print(f"Created pull request #{pull_request.number} ({branch} => {base})")
+        print(f"Created pull request #{pull_request.number} ({head_branch} => {github_repo.owner.login}:{base})")
     except GithubException as e:
         if e.status == 422:
             # A pull request exists for this branch and base
-            head_branch = "{}:{}".format(github_repository.split("/")[0], branch)
             # Get the pull request
             pull_request = github_repo.get_pulls(
                 state="open", base=base, head=head_branch
             )[0]
             # Update title and body
             pull_request.as_issue().edit(title=title, body=body)
-            print(f"Updated pull request #{pull_request.number} ({branch} => {base})")
+            print(f"Updated pull request #{pull_request.number} ({head_branch} => {github_repo.owner.login}:{base})")
         else:
             print(str(e))
             raise

--- a/src/cpr/create_pull_request.py
+++ b/src/cpr/create_pull_request.py
@@ -192,7 +192,7 @@ result = coub.create_or_update_branch(repo, repo_url, commit_message, base, bran
 
 if result["action"] in ["created", "updated"]:
     # The branch was created or updated
-    print(f"Pushing pull request branch to 'origin/{branch}'")
+    print(f"Pushing pull request branch to '{repo.full_name}/{branch}'")
     repo.git.push("--force", repo_url, f"HEAD:refs/heads/{branch}")
 
     # Set the base. It would have been 'None' if not specified as an input
@@ -224,4 +224,5 @@ if result["action"] in ["created", "updated"]:
         os.environ.get("CPR_TEAM_REVIEWERS"),
         os.environ.get("CPR_PROJECT_NAME"),
         os.environ.get("CPR_PROJECT_COLUMN_NAME"),
+        os.environ.get("CPR_REQUEST_TO_PARENT"),
     )

--- a/src/index.js
+++ b/src/index.js
@@ -63,6 +63,7 @@ async function run() {
       project: core.getInput("project"),
       projectColumn: core.getInput("project-column"),
       branch: core.getInput("branch"),
+      request_to_parent: core.getInput("request-to-parent"),
       base: core.getInput("base"),
       branchSuffix: core.getInput("branch-suffix")
     };
@@ -84,6 +85,7 @@ async function run() {
     if (inputs.project) process.env.CPR_PROJECT_NAME = inputs.project;
     if (inputs.projectColumn) process.env.CPR_PROJECT_COLUMN_NAME = inputs.projectColumn;
     if (inputs.branch) process.env.CPR_BRANCH = inputs.branch;
+    if (inputs.request_to_parent) process.env.CPR_REQUEST_TO_PARENT = inputs.request_to_parent;
     if (inputs.base) process.env.CPR_BASE = inputs.base;
     if (inputs.branchSuffix) process.env.CPR_BRANCH_SUFFIX = inputs.branchSuffix;
 


### PR DESCRIPTION
This PR adds a new parameter `repository` that let you customize the repository used for PR

use case:
- configure git to push to the fork
- create a PR between the repo (where github action run) and the fork

Fixes #143

usage:
```yaml

    - name: Checkout code
      uses: actions/checkout@v2
      with:
        ref: master
        token: ${{ secrets.BOT_GITHUB_TOKEN }} # PAT with access to "my-user/fork". It will be needed when create-pull-request will push code

    - name: Switch remote to fork via SSH
      run: |
        git remote set-url origin https://github.com/my-user/fork.git
        git fetch --unshallow -p origin

   # .... steps to update code

    - name: Create Pull Request
      uses: peter-evans/create-pull-request@v2
      with:
        token: ${{ secrets.BOT_GITHUB_TOKEN }} # PAT needed to open PR accross fork
        repository: my-companiy/original # base repository of PR
```