### PR TITLE
Create pull requests in the parent repository of a checked out fork

### DIFF
--- a/.github/workflows/cpr-example-command.yml
+++ b/.github/workflows/cpr-example-command.yml
@@ -30,6 +30,7 @@ jobs:
           project: Example Project
           project-column: To do
           branch: example-patches
+          request-to-parent: false
       - name: Check outputs
         run: |
           echo "Pull Request Number - ${{ env.PULL_REQUEST_NUMBER }}"

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ With the exception of `token`, all inputs are **optional**. If not set, sensible
 | `project` | The name of the project for which a card should be created. Requires `project-column`. | |
 | `project-column` | The name of the project column under which a card should be created. Requires `project`. | |
 | `branch` | The branch name. See [Branch naming](#branch-naming) for details. | `create-pull-request/patch` |
+| `request-to-parent` | Create the pull request in the parent repository of the checked out fork. | `false` |
 | `base` | Sets the pull request base branch. | Defaults to the branch checked out in the workflow. |
 | `branch-suffix` | The branch suffix type. Valid values are `random`, `timestamp` and `short-commit-hash`. See [Branch naming](#branch-naming) for details. | |
 
@@ -186,6 +187,7 @@ jobs:
           project: Example Project
           project-column: To do
           branch: example-patches
+          request-to-parent: false
       - name: Check outputs
         run: |
           echo "Pull Request Number - ${{ env.PULL_REQUEST_NUMBER }}"

--- a/action.yml
+++ b/action.yml
@@ -32,6 +32,9 @@ inputs:
     description: 'The name of the project column under which a card should be created.'
   branch:
     description: 'The pull request branch name.'
+  request-to-parent:
+    description: 'Create the pull request in the parent repository of the checked out fork.'
+    default: false
   base:
     description: 'The pull request base branch.'
   branch-suffix:
@@ -43,5 +46,5 @@ runs:
   using: 'node12'
   main: 'dist/index.js'
 branding:
-  icon: 'git-pull-request'  
+  icon: 'git-pull-request'
   color: 'gray-dark'

--- a/dist/cpr/create_pull_request.py
+++ b/dist/cpr/create_pull_request.py
@@ -224,4 +224,5 @@ if result["action"] in ["created", "updated"]:
         os.environ.get("CPR_TEAM_REVIEWERS"),
         os.environ.get("CPR_PROJECT_NAME"),
         os.environ.get("CPR_PROJECT_COLUMN_NAME"),
+        os.environ.get("CPR_REQUEST_TO_PARENT"),
     )

--- a/dist/index.js
+++ b/dist/index.js
@@ -4275,6 +4275,7 @@ async function run() {
       project: core.getInput("project"),
       projectColumn: core.getInput("project-column"),
       branch: core.getInput("branch"),
+      request_to_parent: core.getInput("request-to-parent"),
       base: core.getInput("base"),
       branchSuffix: core.getInput("branch-suffix")
     };
@@ -4296,6 +4297,7 @@ async function run() {
     if (inputs.project) process.env.CPR_PROJECT_NAME = inputs.project;
     if (inputs.projectColumn) process.env.CPR_PROJECT_COLUMN_NAME = inputs.projectColumn;
     if (inputs.branch) process.env.CPR_BRANCH = inputs.branch;
+    if (inputs.request_to_parent) process.env.CPR_REQUEST_TO_PARENT = inputs.request_to_parent;
     if (inputs.base) process.env.CPR_BASE = inputs.base;
     if (inputs.branchSuffix) process.env.CPR_BRANCH_SUFFIX = inputs.branchSuffix;
 

--- a/docs/concepts-guidelines.md
+++ b/docs/concepts-guidelines.md
@@ -13,6 +13,7 @@ This document covers terminology, how the action works, general usage guidelines
 - [Advanced usage](#advanced-usage)
   - [Creating pull requests in a remote repository](#creating-pull-requests-in-a-remote-repository)
   - [Push using SSH (deploy keys)](#push-using-ssh-deploy-keys)
+  - [Push pull request branches to a fork](#push-pull-request-branches-to-a-fork)
   - [Running in a container](#running-in-a-container)
   - [Creating pull requests on tag push](#creating-pull-requests-on-tag-push)
 
@@ -178,6 +179,34 @@ How to use SSH (deploy keys) with create-pull-request action:
         uses: peter-evans/create-pull-request@v2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+```
+
+### Push pull request branches to a fork
+
+To enforce security, you can use a dedicated user using [machine account](https://help.github.com/en/github/site-policy/github-terms-of-service#3-account-requirements).
+This user has no access to the main repository, it will use their own fork to push code and create the pull request.
+
+1. Create a new github user, then login with this user.
+2. fork the repository.
+3. create a [Personal Access Token (PAT)](https://help.github.com/en/github/authenticating-to-github/creating-a-personal-access-token-for-the-command-line).
+4. logout and go back to your main user.
+5. Add a secret to the repository containing the above PAT.
+6. As shown in the example below, switch the git remote to the fork's url after checkout and set the action input `request-on-parent` to `true`.
+
+```yaml
+      - uses: actions/checkout@v2
+
+      - run: |
+          git config user.password ${{ secrets.PAT }}
+          git remote set-url origin https://github.com/bot-user/fork-project
+          git fetch --unshallow -p origin
+
+      # Make changes to pull request here
+
+      - uses: peter-evans/create-pull-request@v2
+        with:
+          token: ${{ secrets.PAT }}
+          request-on-parent: true
 ```
 
 ### Running in a container

--- a/src/cpr/create_pull_request.py
+++ b/src/cpr/create_pull_request.py
@@ -192,7 +192,7 @@ result = coub.create_or_update_branch(repo, repo_url, commit_message, base, bran
 
 if result["action"] in ["created", "updated"]:
     # The branch was created or updated
-    print(f"Pushing pull request branch to 'origin/{branch}'")
+    print(f"Pushing pull request branch to '{repo.full_name}/{branch}'")
     repo.git.push("--force", repo_url, f"HEAD:refs/heads/{branch}")
 
     # Set the base. It would have been 'None' if not specified as an input
@@ -224,4 +224,5 @@ if result["action"] in ["created", "updated"]:
         os.environ.get("CPR_TEAM_REVIEWERS"),
         os.environ.get("CPR_PROJECT_NAME"),
         os.environ.get("CPR_PROJECT_COLUMN_NAME"),
+        os.environ.get("CPR_REQUEST_TO_PARENT"),
     )

--- a/src/index.js
+++ b/src/index.js
@@ -63,6 +63,7 @@ async function run() {
       project: core.getInput("project"),
       projectColumn: core.getInput("project-column"),
       branch: core.getInput("branch"),
+      request_to_parent: core.getInput("request-to-parent"),
       base: core.getInput("base"),
       branchSuffix: core.getInput("branch-suffix")
     };
@@ -84,6 +85,7 @@ async function run() {
     if (inputs.project) process.env.CPR_PROJECT_NAME = inputs.project;
     if (inputs.projectColumn) process.env.CPR_PROJECT_COLUMN_NAME = inputs.projectColumn;
     if (inputs.branch) process.env.CPR_BRANCH = inputs.branch;
+    if (inputs.request_to_parent) process.env.CPR_REQUEST_TO_PARENT = inputs.request_to_parent;
     if (inputs.base) process.env.CPR_BASE = inputs.base;
     if (inputs.branchSuffix) process.env.CPR_BRANCH_SUFFIX = inputs.branchSuffix;
 


### PR DESCRIPTION
- Adds the `request-to-parent` input. This allows the creation of pull requests in the parent repository of a checked out fork. See the documentation for [push pull request branches to a fork](https://github.com/peter-evans/create-pull-request/blob/master/docs/concepts-guidelines.md#push-pull-request-branches-to-a-fork).