### PR TITLE
Adds option to signoff commits

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ All inputs are **optional**. If not set, sensible defaults will be used.
 | `team-reviewers` | A comma or newline separated list of GitHub teams to request a review from. Note that a `repo` scoped [PAT](https://help.github.com/en/github/authenticating-to-github/creating-a-personal-access-token-for-the-command-line) may be required. See [this issue](https://github.com/peter-evans/create-pull-request/issues/155). | |
 | `milestone` | The number of the milestone to associate this pull request with. | |
 | `draft` | Create a [draft pull request](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests). | `false` |
+| `signoff` | Add Signed-off-by to commit message | `false` |
 
 ### Action outputs
 

--- a/__test__/create-or-update-branch.int.test.ts
+++ b/__test__/create-or-update-branch.int.test.ts
@@ -200,7 +200,8 @@ describe('create-or-update-branch tests', () => {
       commitMessage,
       '',
       BRANCH,
-      REMOTE_NAME
+      REMOTE_NAME,
+      false
     )
     expect(result.action).toEqual('none')
     expect(await gitLogMatches([INIT_COMMIT_MESSAGE])).toBeTruthy()
@@ -215,7 +216,8 @@ describe('create-or-update-branch tests', () => {
       commitMessage,
       '',
       BRANCH,
-      REMOTE_NAME
+      REMOTE_NAME,
+      false
     )
     expect(result.action).toEqual('created')
     expect(await getFileContent(TRACKED_FILE)).toEqual(trackedContent)
@@ -241,7 +243,8 @@ describe('create-or-update-branch tests', () => {
       _commitMessage,
       '',
       BRANCH,
-      REMOTE_NAME
+      REMOTE_NAME,
+      false
     )
     expect(_result.action).toEqual('updated')
     expect(_result.hasDiffWithBase).toBeTruthy()
@@ -260,7 +263,8 @@ describe('create-or-update-branch tests', () => {
       commitMessage,
       '',
       BRANCH,
-      REMOTE_NAME
+      REMOTE_NAME,
+      false
     )
     expect(result.action).toEqual('created')
     expect(await getFileContent(UNTRACKED_FILE)).toEqual(untrackedContent)
@@ -286,7 +290,8 @@ describe('create-or-update-branch tests', () => {
       _commitMessage,
       '',
       BRANCH,
-      REMOTE_NAME
+      REMOTE_NAME,
+      false
     )
     expect(_result.action).toEqual('updated')
     expect(_result.hasDiffWithBase).toBeTruthy()
@@ -307,7 +312,8 @@ describe('create-or-update-branch tests', () => {
       commitMessage,
       '',
       BRANCH,
-      REMOTE_NAME
+      REMOTE_NAME,
+      false
     )
     expect(result.action).toEqual('created')
     expect(await getFileContent(TRACKED_FILE)).toEqual(changes.tracked)
@@ -334,7 +340,8 @@ describe('create-or-update-branch tests', () => {
       _commitMessage,
       '',
       BRANCH,
-      REMOTE_NAME
+      REMOTE_NAME,
+      false
     )
     expect(_result.action).toEqual('none')
     expect(await getFileContent(TRACKED_FILE)).toEqual(changes.tracked)
@@ -353,7 +360,8 @@ describe('create-or-update-branch tests', () => {
       commitMessage,
       '',
       BRANCH,
-      REMOTE_NAME
+      REMOTE_NAME,
+      false
     )
     expect(result.action).toEqual('created')
     expect(await getFileContent(TRACKED_FILE)).toEqual(changes.tracked)
@@ -388,7 +396,8 @@ describe('create-or-update-branch tests', () => {
       _commitMessage,
       '',
       BRANCH,
-      REMOTE_NAME
+      REMOTE_NAME,
+      false
     )
     expect(_result.action).toEqual('updated')
     expect(_result.hasDiffWithBase).toBeTruthy()
@@ -417,7 +426,8 @@ describe('create-or-update-branch tests', () => {
       commitMessage,
       '',
       BRANCH,
-      REMOTE_NAME
+      REMOTE_NAME,
+      false
     )
     expect(result.action).toEqual('created')
     expect(await getFileContent(TRACKED_FILE)).toEqual(changes.tracked)
@@ -443,7 +453,8 @@ describe('create-or-update-branch tests', () => {
       _commitMessage,
       '',
       BRANCH,
-      REMOTE_NAME
+      REMOTE_NAME,
+      false
     )
     expect(_result.action).toEqual('updated')
     expect(_result.hasDiffWithBase).toBeFalsy()
@@ -462,7 +473,8 @@ describe('create-or-update-branch tests', () => {
       commitMessage,
       '',
       BRANCH,
-      REMOTE_NAME
+      REMOTE_NAME,
+      false
     )
     expect(result.action).toEqual('created')
     expect(await getFileContent(TRACKED_FILE)).toEqual(changes.tracked)
@@ -500,7 +512,8 @@ describe('create-or-update-branch tests', () => {
       _commitMessage,
       '',
       BRANCH,
-      REMOTE_NAME
+      REMOTE_NAME,
+      false
     )
     expect(_result.action).toEqual('updated')
     expect(_result.hasDiffWithBase).toBeFalsy()
@@ -520,7 +533,8 @@ describe('create-or-update-branch tests', () => {
       commitMessage,
       '',
       BRANCH,
-      REMOTE_NAME
+      REMOTE_NAME,
+      false
     )
     expect(result.action).toEqual('created')
     expect(await getFileContent(TRACKED_FILE)).toEqual(commits.changes.tracked)
@@ -549,7 +563,8 @@ describe('create-or-update-branch tests', () => {
       _commitMessage,
       '',
       BRANCH,
-      REMOTE_NAME
+      REMOTE_NAME,
+      false
     )
     expect(_result.action).toEqual('updated')
     expect(_result.hasDiffWithBase).toBeTruthy()
@@ -573,7 +588,8 @@ describe('create-or-update-branch tests', () => {
       commitMessage,
       '',
       BRANCH,
-      REMOTE_NAME
+      REMOTE_NAME,
+      false
     )
     expect(result.action).toEqual('created')
     expect(await getFileContent(TRACKED_FILE)).toEqual(changes.tracked)
@@ -606,7 +622,8 @@ describe('create-or-update-branch tests', () => {
       _commitMessage,
       '',
       BRANCH,
-      REMOTE_NAME
+      REMOTE_NAME,
+      false
     )
     expect(_result.action).toEqual('updated')
     expect(_result.hasDiffWithBase).toBeTruthy()
@@ -632,7 +649,8 @@ describe('create-or-update-branch tests', () => {
       commitMessage,
       '',
       BRANCH,
-      REMOTE_NAME
+      REMOTE_NAME,
+      false
     )
     expect(result.action).toEqual('created')
     expect(await getFileContent(TRACKED_FILE)).toEqual(changes.tracked)
@@ -673,7 +691,8 @@ describe('create-or-update-branch tests', () => {
       _commitMessage,
       '',
       BRANCH,
-      REMOTE_NAME
+      REMOTE_NAME,
+      false
     )
     expect(_result.action).toEqual('updated')
     expect(_result.hasDiffWithBase).toBeTruthy()
@@ -698,7 +717,8 @@ describe('create-or-update-branch tests', () => {
       commitMessage,
       '',
       BRANCH,
-      FORK_REMOTE_NAME
+      FORK_REMOTE_NAME,
+      false
     )
     expect(result.action).toEqual('created')
     expect(await getFileContent(TRACKED_FILE)).toEqual(changes.tracked)
@@ -725,7 +745,8 @@ describe('create-or-update-branch tests', () => {
       _commitMessage,
       '',
       BRANCH,
-      FORK_REMOTE_NAME
+      FORK_REMOTE_NAME,
+      false
     )
     expect(_result.action).toEqual('updated')
     expect(_result.hasDiffWithBase).toBeTruthy()
@@ -748,7 +769,8 @@ describe('create-or-update-branch tests', () => {
       commitMessage,
       BASE,
       BRANCH,
-      REMOTE_NAME
+      REMOTE_NAME,
+      false
     )
     expect(result.action).toEqual('none')
     expect(await gitLogMatches([INIT_COMMIT_MESSAGE])).toBeTruthy()
@@ -766,7 +788,8 @@ describe('create-or-update-branch tests', () => {
       commitMessage,
       BASE,
       BRANCH,
-      REMOTE_NAME
+      REMOTE_NAME,
+      false
     )
     expect(result.action).toEqual('created')
     expect(await getFileContent(TRACKED_FILE)).toEqual(trackedContent)
@@ -795,7 +818,8 @@ describe('create-or-update-branch tests', () => {
       _commitMessage,
       BASE,
       BRANCH,
-      REMOTE_NAME
+      REMOTE_NAME,
+      false
     )
     expect(_result.action).toEqual('updated')
     expect(_result.hasDiffWithBase).toBeTruthy()
@@ -817,7 +841,8 @@ describe('create-or-update-branch tests', () => {
       commitMessage,
       BASE,
       BRANCH,
-      REMOTE_NAME
+      REMOTE_NAME,
+      false
     )
     expect(result.action).toEqual('created')
     expect(await getFileContent(UNTRACKED_FILE)).toEqual(untrackedContent)
@@ -846,7 +871,8 @@ describe('create-or-update-branch tests', () => {
       _commitMessage,
       BASE,
       BRANCH,
-      REMOTE_NAME
+      REMOTE_NAME,
+      false
     )
     expect(_result.action).toEqual('updated')
     expect(_result.hasDiffWithBase).toBeTruthy()
@@ -870,7 +896,8 @@ describe('create-or-update-branch tests', () => {
       commitMessage,
       BASE,
       BRANCH,
-      REMOTE_NAME
+      REMOTE_NAME,
+      false
     )
     expect(result.action).toEqual('created')
     expect(await getFileContent(TRACKED_FILE)).toEqual(changes.tracked)
@@ -900,7 +927,8 @@ describe('create-or-update-branch tests', () => {
       _commitMessage,
       BASE,
       BRANCH,
-      REMOTE_NAME
+      REMOTE_NAME,
+      false
     )
     expect(_result.action).toEqual('none')
     expect(await getFileContent(TRACKED_FILE)).toEqual(changes.tracked)
@@ -922,7 +950,8 @@ describe('create-or-update-branch tests', () => {
       commitMessage,
       BASE,
       BRANCH,
-      REMOTE_NAME
+      REMOTE_NAME,
+      false
     )
     expect(result.action).toEqual('created')
     expect(await getFileContent(TRACKED_FILE)).toEqual(changes.tracked)
@@ -960,7 +989,8 @@ describe('create-or-update-branch tests', () => {
       _commitMessage,
       BASE,
       BRANCH,
-      REMOTE_NAME
+      REMOTE_NAME,
+      false
     )
     expect(_result.action).toEqual('updated')
     expect(_result.hasDiffWithBase).toBeTruthy()
@@ -992,7 +1022,8 @@ describe('create-or-update-branch tests', () => {
       commitMessage,
       BASE,
       BRANCH,
-      REMOTE_NAME
+      REMOTE_NAME,
+      false
     )
     expect(result.action).toEqual('created')
     expect(await getFileContent(TRACKED_FILE)).toEqual(changes.tracked)
@@ -1021,7 +1052,8 @@ describe('create-or-update-branch tests', () => {
       _commitMessage,
       BASE,
       BRANCH,
-      REMOTE_NAME
+      REMOTE_NAME,
+      false
     )
     expect(_result.action).toEqual('updated')
     expect(_result.hasDiffWithBase).toBeFalsy()
@@ -1045,7 +1077,8 @@ describe('create-or-update-branch tests', () => {
       commitMessage,
       BASE,
       BRANCH,
-      REMOTE_NAME
+      REMOTE_NAME,
+      false
     )
     expect(result.action).toEqual('created')
     expect(await getFileContent(TRACKED_FILE)).toEqual(changes.tracked)
@@ -1086,7 +1119,8 @@ describe('create-or-update-branch tests', () => {
       _commitMessage,
       BASE,
       BRANCH,
-      REMOTE_NAME
+      REMOTE_NAME,
+      false
     )
     expect(_result.action).toEqual('updated')
     expect(_result.hasDiffWithBase).toBeFalsy()
@@ -1109,7 +1143,8 @@ describe('create-or-update-branch tests', () => {
       commitMessage,
       BASE,
       BRANCH,
-      REMOTE_NAME
+      REMOTE_NAME,
+      false
     )
     expect(result.action).toEqual('created')
     expect(await getFileContent(TRACKED_FILE)).toEqual(commits.changes.tracked)
@@ -1141,7 +1176,8 @@ describe('create-or-update-branch tests', () => {
       _commitMessage,
       BASE,
       BRANCH,
-      REMOTE_NAME
+      REMOTE_NAME,
+      false
     )
     expect(_result.action).toEqual('updated')
     expect(_result.hasDiffWithBase).toBeTruthy()
@@ -1168,7 +1204,8 @@ describe('create-or-update-branch tests', () => {
       commitMessage,
       BASE,
       BRANCH,
-      REMOTE_NAME
+      REMOTE_NAME,
+      false
     )
     expect(result.action).toEqual('created')
     expect(await getFileContent(TRACKED_FILE)).toEqual(changes.tracked)
@@ -1204,7 +1241,8 @@ describe('create-or-update-branch tests', () => {
       _commitMessage,
       BASE,
       BRANCH,
-      REMOTE_NAME
+      REMOTE_NAME,
+      false
     )
     expect(_result.action).toEqual('updated')
     expect(_result.hasDiffWithBase).toBeTruthy()
@@ -1233,7 +1271,8 @@ describe('create-or-update-branch tests', () => {
       commitMessage,
       BASE,
       BRANCH,
-      REMOTE_NAME
+      REMOTE_NAME,
+      false
     )
     expect(result.action).toEqual('created')
     expect(await getFileContent(TRACKED_FILE)).toEqual(changes.tracked)
@@ -1277,7 +1316,8 @@ describe('create-or-update-branch tests', () => {
       _commitMessage,
       BASE,
       BRANCH,
-      REMOTE_NAME
+      REMOTE_NAME,
+      false
     )
     expect(_result.action).toEqual('updated')
     expect(_result.hasDiffWithBase).toBeTruthy()
@@ -1305,7 +1345,8 @@ describe('create-or-update-branch tests', () => {
       commitMessage,
       BASE,
       BRANCH,
-      FORK_REMOTE_NAME
+      FORK_REMOTE_NAME,
+      false
     )
     expect(result.action).toEqual('created')
     expect(await getFileContent(TRACKED_FILE)).toEqual(changes.tracked)
@@ -1335,7 +1376,8 @@ describe('create-or-update-branch tests', () => {
       _commitMessage,
       BASE,
       BRANCH,
-      FORK_REMOTE_NAME
+      FORK_REMOTE_NAME,
+      false
     )
     expect(_result.action).toEqual('updated')
     expect(_result.hasDiffWithBase).toBeTruthy()

--- a/action.yml
+++ b/action.yml
@@ -56,6 +56,9 @@ inputs:
   draft:
     description: 'Create a draft pull request'
     default: false
+  signoff:
+    description: 'Add "Signed-off-by" to commit message'
+    default: false
 outputs:
   pull-request-number:
     description: 'The pull request number'

--- a/src/create-or-update-branch.ts
+++ b/src/create-or-update-branch.ts
@@ -101,7 +101,7 @@ export async function createOrUpdateBranch(
     core.info('Uncommitted changes found. Adding a commit.')
     await git.exec(['add', '-A'])
     if (signoff == true) {
-      await git.commit(['--signoff', '-m', commitMessage])
+      await git.commit(['-m', commitMessage, '-s'])
     } else {
       await git.commit(['-m', commitMessage])
     }

--- a/src/create-or-update-branch.ts
+++ b/src/create-or-update-branch.ts
@@ -77,7 +77,8 @@ export async function createOrUpdateBranch(
   commitMessage: string,
   base: string,
   branch: string,
-  branchRemoteName: string
+  branchRemoteName: string,
+  signoff: boolean
 ): Promise<CreateOrUpdateBranchResult> {
   // Get the working base. This may or may not be the actual base.
   const workingBase = await git.symbolicRef('HEAD', ['--short'])
@@ -99,7 +100,11 @@ export async function createOrUpdateBranch(
   if (await git.isDirty(true)) {
     core.info('Uncommitted changes found. Adding a commit.')
     await git.exec(['add', '-A'])
-    await git.commit(['-m', commitMessage])
+    if (signoff == true) {
+      await git.commit(['--signoff', '-m', commitMessage])
+    } else {
+      await git.commit(['-m', commitMessage])
+    }
   }
 
   // Perform fetch and reset the working base

--- a/src/create-pull-request.ts
+++ b/src/create-pull-request.ts
@@ -23,6 +23,7 @@ export interface Inputs {
   teamReviewers: string[]
   milestone: number
   draft: boolean
+  signoff: boolean
 }
 
 export async function createPullRequest(inputs: Inputs): Promise<void> {
@@ -166,7 +167,8 @@ export async function createPullRequest(inputs: Inputs): Promise<void> {
       inputs.commitMessage,
       inputs.base,
       inputs.branch,
-      branchRemoteName
+      branchRemoteName,
+      inputs.signoff
     )
     core.endGroup()
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -22,7 +22,8 @@ async function run(): Promise<void> {
       reviewers: utils.getInputAsArray('reviewers'),
       teamReviewers: utils.getInputAsArray('team-reviewers'),
       milestone: Number(core.getInput('milestone')),
-      draft: core.getInput('draft') === 'true'
+      draft: core.getInput('draft') === 'true',
+      signoff: core.getInput('signoff') === 'true'
     }
     core.debug(`Inputs: ${inspect(inputs)}`)
 


### PR DESCRIPTION
This PR adds the ability to signoff the automatically created commits to enable DCO requirements for pull requests.
It adds the option `signoff` and the flag `-s` to `git commit` which adds "Signed-off-by: author < email >" with the value of `commiter` to the commit message.

Test cases for the new option are not included.