### PR TITLE
Support GitHub Enterprise Server

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -1157,8 +1157,16 @@ exports.getRepoPath = getRepoPath;
 function getRemoteDetail(remoteUrl) {
     // Parse the protocol and github repository from a URL
     // e.g. HTTPS, peter-evans/create-pull-request
-    const httpsUrlPattern = /^https:\/\/.*@?github.com\/(.+\/.+)$/i;
-    const sshUrlPattern = /^git@github.com:(.+\/.+).git$/i;
+    let githubServerUrl = process.env['GITHUB_SERVER_URL'];
+    if (!githubServerUrl) {
+        githubServerUrl = 'https://github.com';
+    }
+    const githubServerMatch = githubServerUrl.match(/^https?:\/\/(.+)$/i);
+    if (!githubServerMatch) {
+        throw new Error('Could not parse GitHub Server name');
+    }
+    const httpsUrlPattern = new RegExp('^https?://.*@?' + githubServerMatch[1] + '/(.+/.+)$', 'i');
+    const sshUrlPattern = new RegExp('^git@' + githubServerMatch[1] + ':(.+/.+).git$', 'i');
     const httpsMatch = remoteUrl.match(httpsUrlPattern);
     if (httpsMatch) {
         return {

--- a/dist/index.js
+++ b/dist/index.js
@@ -901,6 +901,7 @@ class GitHubHelper {
         if (token) {
             options.auth = `${token}`;
         }
+        options.baseUrl = process.env['GITHUB_API_URL'] || 'https://api.github.com';
         this.octokit = new octokit_client_1.Octokit(options);
     }
     parseRepository(repository) {
@@ -1157,11 +1158,8 @@ exports.getRepoPath = getRepoPath;
 function getRemoteDetail(remoteUrl) {
     // Parse the protocol and github repository from a URL
     // e.g. HTTPS, peter-evans/create-pull-request
-    let githubServerUrl = process.env['GITHUB_SERVER_URL'];
-    if (!githubServerUrl) {
-        githubServerUrl = 'https://github.com';
-    }
-    const githubServerMatch = githubServerUrl.match(/^https?:\/\/(.+)$/i);
+    const githubUrl = process.env['GITHUB_SERVER_URL'] || 'https://github.com';
+    const githubServerMatch = githubUrl.match(/^https?:\/\/(.+)$/i);
     if (!githubServerMatch) {
         throw new Error('Could not parse GitHub Server name');
     }

--- a/src/github-helper.ts
+++ b/src/github-helper.ts
@@ -23,6 +23,7 @@ export class GitHubHelper {
     if (token) {
       options.auth = `${token}`
     }
+    options.baseUrl = process.env['GITHUB_API_URL'] || 'https://api.github.com'
     this.octokit = new Octokit(options)
   }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -39,8 +39,24 @@ interface RemoteDetail {
 export function getRemoteDetail(remoteUrl: string): RemoteDetail {
   // Parse the protocol and github repository from a URL
   // e.g. HTTPS, peter-evans/create-pull-request
-  const httpsUrlPattern = /^https:\/\/.*@?github.com\/(.+\/.+)$/i
-  const sshUrlPattern = /^git@github.com:(.+\/.+).git$/i
+  let githubServerUrl = process.env['GITHUB_SERVER_URL']
+  if (!githubServerUrl) {
+    githubServerUrl = 'https://github.com'
+  }
+
+  const githubServerMatch = githubServerUrl.match(/^https?:\/\/(.+)$/i)
+  if (!githubServerMatch) {
+    throw new Error('Could not parse GitHub Server name')
+  }
+
+  const httpsUrlPattern = new RegExp(
+    '^https?://.*@?' + githubServerMatch[1] + '/(.+/.+)$',
+    'i'
+  )
+  const sshUrlPattern = new RegExp(
+    '^git@' + githubServerMatch[1] + ':(.+/.+).git$',
+    'i'
+  )
 
   const httpsMatch = remoteUrl.match(httpsUrlPattern)
   if (httpsMatch) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -39,12 +39,9 @@ interface RemoteDetail {
 export function getRemoteDetail(remoteUrl: string): RemoteDetail {
   // Parse the protocol and github repository from a URL
   // e.g. HTTPS, peter-evans/create-pull-request
-  let githubServerUrl = process.env['GITHUB_SERVER_URL']
-  if (!githubServerUrl) {
-    githubServerUrl = 'https://github.com'
-  }
+  const githubUrl = process.env['GITHUB_SERVER_URL'] || 'https://github.com'
 
-  const githubServerMatch = githubServerUrl.match(/^https?:\/\/(.+)$/i)
+  const githubServerMatch = githubUrl.match(/^https?:\/\/(.+)$/i)
   if (!githubServerMatch) {
     throw new Error('Could not parse GitHub Server name')
   }


### PR DESCRIPTION
* only minimal changes are needed to support GitHub Enterprise with this action
* use `GITHUB_SERVER_URL` and `GITHUB_API_URL` in all places that have been github.com specific before
* successfully tested with GitHub Enterprise Server 2.22