### PR TITLE
feat: add flag to skip unstaged files

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ All inputs are **optional**. If not set, sensible defaults will be used.
 | `team-reviewers` | A comma or newline-separated list of GitHub teams to request a review from. Note that a `repo` scoped [PAT](https://docs.github.com/en/github/authenticating-to-github/creating-a-personal-access-token) may be required. See [this issue](https://github.com/peter-evans/create-pull-request/issues/155). | |
 | `milestone` | The number of the milestone to associate this pull request with. | |
 | `draft` | Create a [draft pull request](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests). | `false` |
-
+| `skip-unstaged-files` | Skips adding any unstaged files when creating the pull request | `false` |
 ### Action outputs
 
 The following outputs can be used by subsequent workflow steps.

--- a/action.yml
+++ b/action.yml
@@ -64,6 +64,9 @@ inputs:
   draft:
     description: 'Create a draft pull request'
     default: false
+  skinUnstagedFiles:
+    description: 'Skips any unstaged files when creating a pull request.'
+    default: false
 outputs:
   pull-request-number:
     description: 'The pull request number'

--- a/src/create-or-update-branch.ts
+++ b/src/create-or-update-branch.ts
@@ -91,7 +91,8 @@ export async function createOrUpdateBranch(
   base: string,
   branch: string,
   branchRemoteName: string,
-  signoff: boolean
+  signoff: boolean,
+  skipUnstagedFiles: boolean
 ): Promise<CreateOrUpdateBranchResult> {
   // Get the working base.
   // When a ref, it may or may not be the actual base.
@@ -117,7 +118,7 @@ export async function createOrUpdateBranch(
   const tempBranch = uuidv4()
   await git.checkout(tempBranch, 'HEAD')
   // Commit any uncommitted changes
-  if (await git.isDirty(true)) {
+  if (skipUnstagedFiles === false && (await git.isDirty(true))) {
     core.info('Uncommitted changes found. Adding a commit.')
     await git.exec(['add', '-A'])
     const params = ['-m', commitMessage]

--- a/src/create-pull-request.ts
+++ b/src/create-pull-request.ts
@@ -29,6 +29,7 @@ export interface Inputs {
   teamReviewers: string[]
   milestone: number
   draft: boolean
+  skipUnstagedFiles: boolean
 }
 
 export async function createPullRequest(inputs: Inputs): Promise<void> {
@@ -173,7 +174,8 @@ export async function createPullRequest(inputs: Inputs): Promise<void> {
       inputs.base,
       inputs.branch,
       branchRemoteName,
-      inputs.signoff
+      inputs.signoff,
+      inputs.skipUnstagedFiles
     )
     core.endGroup()
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -24,7 +24,8 @@ async function run(): Promise<void> {
       reviewers: utils.getInputAsArray('reviewers'),
       teamReviewers: utils.getInputAsArray('team-reviewers'),
       milestone: Number(core.getInput('milestone')),
-      draft: core.getInput('draft') === 'true'
+      draft: core.getInput('draft') === 'true',
+      skipUnstagedFiles: core.getInput('skip-unstaged-files') === 'true'
     }
     core.debug(`Inputs: ${inspect(inputs)}`)
 


### PR DESCRIPTION
Hey there!, thanks for creating the action first and foremost.

I've come across some issues where we want to control which files are staged beforehand, this mainly happens to us because our actions are cloning other private repos to run some commands, this produces some artifacts that are used during the CI but are definitely not meant to be committed.

This obviously produces a bit of an overhead having to clean up whatever artifact we generated so this action doesnt commit anything we don't want.

`skip-unstaged-files` would do just that, if it's set to `true` it skips `git add -A`.

If this approach is correct I'd love to know what would be left to merge this, I had some issues with running tests as I'm missing some libs in `lib/**` so I'm guessing it's not too straightforward to run them?

Thanks!
