### PR TITLE
Feature: add remove-labels option for clearing existing labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,8 @@ All inputs are **optional**. If not set, sensible defaults will be used.
 | `push-to-fork` | A fork of the checked-out parent repository to which the pull request branch will be pushed. e.g. `owner/repo-fork`. The pull request will be created to merge the fork's branch into the parent's base. See [push pull request branches to a fork](docs/concepts-guidelines.md#push-pull-request-branches-to-a-fork) for details. | |
 | `title` | The title of the pull request. | `Changes by create-pull-request action` |
 | `body` | The body of the pull request. | `Automated changes by [create-pull-request](https://github.com/peter-evans/create-pull-request) GitHub action` |
-| `labels` | A comma or newline-separated list of labels. | |
+| `labels` | A comma or newline-separated list of labels to add. | |
+| `remove-labels` | If true, will remove all existing labels. | `false` |
 | `assignees` | A comma or newline-separated list of assignees (GitHub usernames). | |
 | `reviewers` | A comma or newline-separated list of reviewers (GitHub usernames) to request a review from. | |
 | `team-reviewers` | A comma or newline-separated list of GitHub teams to request a review from. Note that a `repo` scoped [PAT](https://docs.github.com/en/github/authenticating-to-github/creating-a-personal-access-token) may be required. See [this issue](https://github.com/peter-evans/create-pull-request/issues/155). | |

--- a/action.yml
+++ b/action.yml
@@ -1,39 +1,39 @@
-name: 'Create Pull Request'
-description: 'Creates a pull request for changes to your repository in the actions workspace'
+name: "Create Pull Request"
+description: "Creates a pull request for changes to your repository in the actions workspace"
 inputs:
   token:
-    description: 'GITHUB_TOKEN or a `repo` scoped Personal Access Token (PAT)'
+    description: "GITHUB_TOKEN or a `repo` scoped Personal Access Token (PAT)"
     default: ${{ github.token }}
   path:
     description: >
       Relative path under $GITHUB_WORKSPACE to the repository.
       Defaults to $GITHUB_WORKSPACE.
   commit-message:
-    description: 'The message to use when committing changes.'
-    default: '[create-pull-request] automated change'
+    description: "The message to use when committing changes."
+    default: "[create-pull-request] automated change"
   committer:
     description: >
       The committer name and email address in the format `Display Name <email@address.com>`.
       Defaults to the GitHub Actions bot user.
-    default: 'GitHub <noreply@github.com>'
+    default: "GitHub <noreply@github.com>"
   author:
     description: >
       The author name and email address in the format `Display Name <email@address.com>`.
       Defaults to the user who triggered the workflow run.
-    default: '${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>'
+    default: "${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>"
   signoff:
-    description: 'Add `Signed-off-by` line by the committer at the end of the commit log message.'
+    description: "Add `Signed-off-by` line by the committer at the end of the commit log message."
     default: false
   branch:
-    description: 'The pull request branch name.'
-    default: 'create-pull-request/patch'
+    description: "The pull request branch name."
+    default: "create-pull-request/patch"
   delete-branch:
     description: >
       Delete the `branch` when closing pull requests, and when undeleted after merging.
       Recommend `true`.
     default: false
   branch-suffix:
-    description: 'The branch suffix type when using the alternative branching strategy.'
+    description: "The branch suffix type when using the alternative branching strategy."
   base:
     description: >
       The pull request base branch.
@@ -44,36 +44,39 @@ inputs:
       e.g. `owner/repo-fork`.
       The pull request will be created to merge the fork's branch into the parent's base.
   title:
-    description: 'The title of the pull request.'
-    default: 'Changes by create-pull-request action'
+    description: "The title of the pull request."
+    default: "Changes by create-pull-request action"
   body:
-    description: 'The body of the pull request.'
-    default: 'Automated changes by [create-pull-request](https://github.com/peter-evans/create-pull-request) GitHub action'
+    description: "The body of the pull request."
+    default: "Automated changes by [create-pull-request](https://github.com/peter-evans/create-pull-request) GitHub action"
   labels:
-    description: 'A comma or newline separated list of labels.'
+    description: "A comma or newline separated list of labels to add."
+  remove-labels:
+    description: "If true, remove all existing labels."
+    default: false
   assignees:
-    description: 'A comma or newline separated list of assignees (GitHub usernames).'
+    description: "A comma or newline separated list of assignees (GitHub usernames)."
   reviewers:
-    description: 'A comma or newline separated list of reviewers (GitHub usernames) to request a review from.'
+    description: "A comma or newline separated list of reviewers (GitHub usernames) to request a review from."
   team-reviewers:
     description: >
       A comma or newline separated list of GitHub teams to request a review from.
       Note that a `repo` scoped Personal Access Token (PAT) may be required.
   milestone:
-    description: 'The number of the milestone to associate the pull request with.'
+    description: "The number of the milestone to associate the pull request with."
   draft:
-    description: 'Create a draft pull request'
+    description: "Create a draft pull request"
     default: false
 outputs:
   pull-request-number:
-    description: 'The pull request number'
+    description: "The pull request number"
   pull-request-url:
-    description: 'The URL of the pull request.'
+    description: "The URL of the pull request."
   pull-request-operation:
-    description: 'The pull request operation performed by the action, `created`, `updated` or `closed`.'
+    description: "The pull request operation performed by the action, `created`, `updated` or `closed`."
 runs:
-  using: 'node12'
-  main: 'dist/index.js'
+  using: "node12"
+  main: "dist/index.js"
 branding:
-  icon: 'git-pull-request'
-  color: 'gray-dark'
+  icon: "git-pull-request"
+  color: "gray-dark"

--- a/dist/index.js
+++ b/dist/index.js
@@ -263,9 +263,9 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.createPullRequest = void 0;
 const core = __importStar(__nccwpck_require__(2186));
 const create_or_update_branch_1 = __nccwpck_require__(8363);
-const github_helper_1 = __nccwpck_require__(446);
-const git_command_manager_1 = __nccwpck_require__(738);
 const git_auth_helper_1 = __nccwpck_require__(2565);
+const git_command_manager_1 = __nccwpck_require__(738);
+const github_helper_1 = __nccwpck_require__(446);
 const utils = __importStar(__nccwpck_require__(918));
 function createPullRequest(inputs) {
     return __awaiter(this, void 0, void 0, function* () {
@@ -984,6 +984,11 @@ class GitHubHelper {
                 core.info(`Applying milestone '${inputs.milestone}'`);
                 yield this.octokit.rest.issues.update(Object.assign(Object.assign({}, this.parseRepository(baseRepository)), { issue_number: pull.number, milestone: inputs.milestone }));
             }
+            // Remove labels
+            if (inputs.removeLabels) {
+                core.info(`Removing ALL labels`);
+                yield this.octokit.rest.issues.removeAllLabels(Object.assign(Object.assign({}, this.parseRepository(baseRepository)), { issue_number: pull.number }));
+            }
             // Apply labels
             if (inputs.labels.length > 0) {
                 core.info(`Applying labels '${inputs.labels}'`);
@@ -1061,8 +1066,8 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 const core = __importStar(__nccwpck_require__(2186));
-const create_pull_request_1 = __nccwpck_require__(3780);
 const util_1 = __nccwpck_require__(1669);
+const create_pull_request_1 = __nccwpck_require__(3780);
 const utils = __importStar(__nccwpck_require__(918));
 function run() {
     return __awaiter(this, void 0, void 0, function* () {
@@ -1082,6 +1087,7 @@ function run() {
                 title: core.getInput('title'),
                 body: core.getInput('body'),
                 labels: utils.getInputAsArray('labels'),
+                removeLabels: core.getInput('remove-labels') === 'true',
                 assignees: utils.getInputAsArray('assignees'),
                 reviewers: utils.getInputAsArray('reviewers'),
                 teamReviewers: utils.getInputAsArray('team-reviewers'),

--- a/src/create-pull-request.ts
+++ b/src/create-pull-request.ts
@@ -4,9 +4,9 @@ import {
   getWorkingBaseAndType,
   WorkingBaseType
 } from './create-or-update-branch'
-import {GitHubHelper} from './github-helper'
-import {GitCommandManager} from './git-command-manager'
 import {GitAuthHelper} from './git-auth-helper'
+import {GitCommandManager} from './git-command-manager'
+import {GitHubHelper} from './github-helper'
 import * as utils from './utils'
 
 export interface Inputs {
@@ -24,6 +24,7 @@ export interface Inputs {
   title: string
   body: string
   labels: string[]
+  removeLabels: boolean
   assignees: string[]
   reviewers: string[]
   teamReviewers: string[]

--- a/src/github-helper.ts
+++ b/src/github-helper.ts
@@ -129,6 +129,14 @@ export class GitHubHelper {
         milestone: inputs.milestone
       })
     }
+    // Remove labels
+    if (inputs.removeLabels) {
+      core.info(`Removing ALL labels`)
+      await this.octokit.rest.issues.removeAllLabels({
+        ...this.parseRepository(baseRepository),
+        issue_number: pull.number
+      })
+    }
     // Apply labels
     if (inputs.labels.length > 0) {
       core.info(`Applying labels '${inputs.labels}'`)

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,6 @@
 import * as core from '@actions/core'
-import {Inputs, createPullRequest} from './create-pull-request'
 import {inspect} from 'util'
+import {createPullRequest, Inputs} from './create-pull-request'
 import * as utils from './utils'
 
 async function run(): Promise<void> {
@@ -20,6 +20,7 @@ async function run(): Promise<void> {
       title: core.getInput('title'),
       body: core.getInput('body'),
       labels: utils.getInputAsArray('labels'),
+      removeLabels: core.getInput('remove-labels') === 'true',
       assignees: utils.getInputAsArray('assignees'),
       reviewers: utils.getInputAsArray('reviewers'),
       teamReviewers: utils.getInputAsArray('team-reviewers'),


### PR DESCRIPTION
As above, this is useful when using a label-based merge queue system (or anything that stores state in labels) that we wish to reset on creating a new PR.

Note: I have YML formatting which led to the quote change, let me know if it's desirable to undo.