### PR TITLE
docs: Update to include app permissions needed to add teams as reviewers

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ All inputs are **optional**. If not set, sensible defaults will be used.
 | `labels` | A comma or newline-separated list of labels. | |
 | `assignees` | A comma or newline-separated list of assignees (GitHub usernames). | |
 | `reviewers` | A comma or newline-separated list of reviewers (GitHub usernames) to request a review from. | |
-| `team-reviewers` | A comma or newline-separated list of GitHub teams to request a review from. Note that a `repo` scoped [PAT](https://docs.github.com/en/github/authenticating-to-github/creating-a-personal-access-token) may be required. See [this issue](https://github.com/peter-evans/create-pull-request/issues/155). | |
+| `team-reviewers` | A comma or newline-separated list of GitHub teams to request a review from. Note that a `repo` scoped [PAT](https://docs.github.com/en/github/authenticating-to-github/creating-a-personal-access-token) may be required. See [this issue](https://github.com/peter-evans/create-pull-request/issues/155). If using a GitHub App, refer to [Authenticating with GitHub App generated tokens](docs/concepts-guidelines.md#authenticating-with-github-app-generated-tokens) for the proper permissions. | |
 | `milestone` | The number of the milestone to associate this pull request with. | |
 | `draft` | Create a [draft pull request](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests). | `false` |
 

--- a/docs/concepts-guidelines.md
+++ b/docs/concepts-guidelines.md
@@ -248,6 +248,8 @@ GitHub App generated tokens are more secure than using a PAT because GitHub App 
     - Uncheck `Active` under `Webhook`. You do not need to enter a `Webhook URL`.
     - Under `Repository permissions: Contents` select `Access: Read & write`.
     - Under `Repository permissions: Pull requests` select `Access: Read & write`.
+    - Under `Organization permissions: Members` select `Access: Read-only`.
+      - **NOTE**: Only needed if you would like add teams as reviewers to PRs.
 
 2. Create a Private key from the App settings page and store it securely.
 


### PR DESCRIPTION
I encountered the same issue raised in #155 with a GitHub App. However, was able to get things to work by allowing read only access to Members to the GitHub App. Updating the docs!