### PR TITLE
Add argument add-pattern-array

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ lib/
 node_modules/
 
 .DS_Store
+.idea

--- a/README.md
+++ b/README.md
@@ -62,7 +62,8 @@ All inputs are **optional**. If not set, sensible defaults will be used.
 | `reviewers` | A comma or newline-separated list of reviewers (GitHub usernames) to request a review from. | |
 | `team-reviewers` | A comma or newline-separated list of GitHub teams to request a review from. Note that a `repo` scoped [PAT](https://docs.github.com/en/github/authenticating-to-github/creating-a-personal-access-token) may be required. See [this issue](https://github.com/peter-evans/create-pull-request/issues/155). If using a GitHub App, refer to [Authenticating with GitHub App generated tokens](docs/concepts-guidelines.md#authenticating-with-github-app-generated-tokens) for the proper permissions. | |
 | `milestone` | The number of the milestone to associate this pull request with. | |
-| `draft` | Create a [draft pull request](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests). | `false` |
+| `draft` | Create a [draft pull request](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests). | `false` | |
+| `add-pattern-array` | A comma or newline-separated list of file path patterns, by example `**.txt, **some_dir**.png`. | `-A (what means --all)` |
 
 For self-hosted runners behind a corporate proxy set the `https_proxy` environment variable.
 ```yml

--- a/README.md
+++ b/README.md
@@ -123,6 +123,20 @@ To use this strategy, set input `branch-suffix` with one of the following option
 
 - `short-commit-hash` - Commits will be made to a branch suffixed with the short SHA1 commit hash. e.g. `create-pull-request/patch-fcdfb59`, `create-pull-request/patch-394710b`
 
+### Controlling committed files
+
+You may control files to added on pull request with argument `add-pattern-array`.
+It specify `git add` pattern of files. By example:
+```yml
+      ...
+      uses: peter-evans/create-pull-request@main #TODO put next version here
+        with:
+          add-pattern-array: |
+            **.txt
+            **some/dirs**.png
+          token: ${{ secrets.GITHUB_TOKEN }}
+```
+
 ### Controlling commits
 
 As well as relying on the action to handle uncommitted changes, you can additionally make your own commits before the action runs.

--- a/action.yml
+++ b/action.yml
@@ -64,6 +64,10 @@ inputs:
   draft:
     description: 'Create a draft pull request'
     default: false
+  add-pattern-array:
+    description: 'git add [pattern]'
+    default: |
+      -A
 outputs:
   pull-request-number:
     description: 'The pull request number'

--- a/dist/index.js
+++ b/dist/index.js
@@ -98,7 +98,7 @@ function splitLines(multilineString) {
         .map(s => s.trim())
         .filter(x => x !== '');
 }
-function createOrUpdateBranch(git, commitMessage, base, branch, branchRemoteName, signoff) {
+function createOrUpdateBranch(git, commitMessage, base, branch, branchRemoteName, signoff, filePatterns) {
     return __awaiter(this, void 0, void 0, function* () {
         // Get the working base.
         // When a ref, it may or may not be the actual base.
@@ -124,7 +124,9 @@ function createOrUpdateBranch(git, commitMessage, base, branch, branchRemoteName
         // Commit any uncommitted changes
         if (yield git.isDirty(true)) {
             core.info('Uncommitted changes found. Adding a commit.');
-            yield git.exec(['add', '-A']);
+            for (const filePattern of filePatterns) {
+                yield git.exec(['add', filePattern]);
+            }
             const params = ['-m', commitMessage];
             if (signoff) {
                 params.push('--signoff');
@@ -377,7 +379,7 @@ function createPullRequest(inputs) {
             core.endGroup();
             // Create or update the pull request branch
             core.startGroup('Create or update the pull request branch');
-            const result = yield (0, create_or_update_branch_1.createOrUpdateBranch)(git, inputs.commitMessage, inputs.base, inputs.branch, branchRemoteName, inputs.signoff);
+            const result = yield (0, create_or_update_branch_1.createOrUpdateBranch)(git, inputs.commitMessage, inputs.base, inputs.branch, branchRemoteName, inputs.signoff, inputs.addPatternArray);
             core.endGroup();
             if (['created', 'updated'].includes(result.action)) {
                 // The branch was created or updated
@@ -1090,7 +1092,8 @@ function run() {
                 reviewers: utils.getInputAsArray('reviewers'),
                 teamReviewers: utils.getInputAsArray('team-reviewers'),
                 milestone: Number(core.getInput('milestone')),
-                draft: core.getInput('draft') === 'true'
+                draft: core.getInput('draft') === 'true',
+                addPatternArray: utils.getInputAsArray('add-pattern-array')
             };
             core.debug(`Inputs: ${(0, util_1.inspect)(inputs)}`);
             yield (0, create_pull_request_1.createPullRequest)(inputs);

--- a/dist/index.js
+++ b/dist/index.js
@@ -132,6 +132,8 @@ function createOrUpdateBranch(git, commitMessage, base, branch, branchRemoteName
                 params.push('--signoff');
             }
             yield git.commit(params);
+            git.exec(['reset', '--hard']);
+            git.exec(['clean', '-f']);
         }
         // Perform fetch and reset the working base
         // Commits made during the workflow will be removed

--- a/dist/index.js
+++ b/dist/index.js
@@ -125,7 +125,7 @@ function createOrUpdateBranch(git, commitMessage, base, branch, branchRemoteName
         if (yield git.isDirty(true)) {
             core.info('Uncommitted changes found. Adding a commit.');
             for (const filePattern of filePatterns) {
-                yield git.exec(['add', filePattern]);
+                yield git.exec(['add', filePattern], true);
             }
             const params = ['-m', commitMessage];
             if (signoff) {

--- a/src/create-or-update-branch.ts
+++ b/src/create-or-update-branch.ts
@@ -91,7 +91,8 @@ export async function createOrUpdateBranch(
   base: string,
   branch: string,
   branchRemoteName: string,
-  signoff: boolean
+  signoff: boolean,
+  filePatterns: string[]
 ): Promise<CreateOrUpdateBranchResult> {
   // Get the working base.
   // When a ref, it may or may not be the actual base.
@@ -120,7 +121,9 @@ export async function createOrUpdateBranch(
   // Commit any uncommitted changes
   if (await git.isDirty(true)) {
     core.info('Uncommitted changes found. Adding a commit.')
-    await git.exec(['add', '-A'])
+    for (const filePattern of filePatterns) {
+      await git.exec(['add', filePattern])
+    }
     const params = ['-m', commitMessage]
     if (signoff) {
       params.push('--signoff')

--- a/src/create-or-update-branch.ts
+++ b/src/create-or-update-branch.ts
@@ -129,6 +129,8 @@ export async function createOrUpdateBranch(
       params.push('--signoff')
     }
     await git.commit(params)
+    git.exec(['reset', '--hard'])
+    git.exec(['clean', '-f'])
   }
 
   // Perform fetch and reset the working base

--- a/src/create-or-update-branch.ts
+++ b/src/create-or-update-branch.ts
@@ -122,7 +122,7 @@ export async function createOrUpdateBranch(
   if (await git.isDirty(true)) {
     core.info('Uncommitted changes found. Adding a commit.')
     for (const filePattern of filePatterns) {
-      await git.exec(['add', filePattern])
+      await git.exec(['add', filePattern], true)
     }
     const params = ['-m', commitMessage]
     if (signoff) {

--- a/src/create-pull-request.ts
+++ b/src/create-pull-request.ts
@@ -29,6 +29,7 @@ export interface Inputs {
   teamReviewers: string[]
   milestone: number
   draft: boolean
+  addPatternArray: string[]
 }
 
 export async function createPullRequest(inputs: Inputs): Promise<void> {
@@ -173,7 +174,8 @@ export async function createPullRequest(inputs: Inputs): Promise<void> {
       inputs.base,
       inputs.branch,
       branchRemoteName,
-      inputs.signoff
+      inputs.signoff,
+      inputs.addPatternArray
     )
     core.endGroup()
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -24,7 +24,8 @@ async function run(): Promise<void> {
       reviewers: utils.getInputAsArray('reviewers'),
       teamReviewers: utils.getInputAsArray('team-reviewers'),
       milestone: Number(core.getInput('milestone')),
-      draft: core.getInput('draft') === 'true'
+      draft: core.getInput('draft') === 'true',
+      addPatternArray: utils.getInputAsArray('add-pattern-array')
     }
     core.debug(`Inputs: ${inspect(inputs)}`)
 


### PR DESCRIPTION
Add argument `add-pattern-array` to commit file with patterns. All other files will be cleaned.

Usage:

```yml
      - name: Create Pull Request
        uses: tutu-ru-mobile/create-pull-request@tutu  # Off course here will changed to peter-evans/...
        with:
          add-pattern-array: |
            **.txt
            **some/dirs**.png
          token: ${{ secrets.GITHUB_TOKEN }}
```

Working sample:
https://github.com/avdim/test_pull_request_creation/blob/main/.github/workflows/blank.yml

Also need to fix README.md, because in version @v3 this argument not exists. I put @main branch in README.md

What do you think about this PR ?