### PR TITLE
feat: support for fail-if-no-changes input

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ All inputs are **optional**. If not set, sensible defaults will be used.
 | `team-reviewers` | A comma or newline-separated list of GitHub teams to request a review from. Note that a `repo` scoped [PAT](https://docs.github.com/en/github/authenticating-to-github/creating-a-personal-access-token) may be required. See [this issue](https://github.com/peter-evans/create-pull-request/issues/155). If using a GitHub App, refer to [Authenticating with GitHub App generated tokens](docs/concepts-guidelines.md#authenticating-with-github-app-generated-tokens) for the proper permissions. | |
 | `milestone` | The number of the milestone to associate this pull request with. | |
 | `draft` | Create a [draft pull request](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests). | `false` |
+| `fail-if-no-changes` | Whether the workflow should fail if a pull request wasn't created/updated. | `false` |
 
 For self-hosted runners behind a corporate proxy set the `https_proxy` environment variable.
 ```yml

--- a/__test__/create-or-update-branch.int.test.ts
+++ b/__test__/create-or-update-branch.int.test.ts
@@ -226,7 +226,7 @@ describe('create-or-update-branch tests', () => {
       false,
       ADD_PATHS
     )
-    expect(result.action).toEqual('none')
+    expect(result.action).toEqual('not-created')
     expect(await gitLogMatches([INIT_COMMIT_MESSAGE])).toBeTruthy()
   })
 
@@ -1004,7 +1004,7 @@ describe('create-or-update-branch tests', () => {
       false,
       ADD_PATHS
     )
-    expect(result.action).toEqual('none')
+    expect(result.action).toEqual('not-created')
     expect(await gitLogMatches([INIT_COMMIT_MESSAGE])).toBeTruthy()
   })
 
@@ -1869,6 +1869,6 @@ describe('create-or-update-branch tests', () => {
       ADD_PATHS
     )
     // The action cannot successfully create the branch
-    expect(result.action).toEqual('none')
+    expect(result.action).toEqual('not-created')
   })
 })

--- a/action.yml
+++ b/action.yml
@@ -71,6 +71,9 @@ inputs:
   draft:
     description: 'Create a draft pull request'
     default: false
+  fail-if-no-changes:
+    description: 'Whether the job should fail if no changes are made.'
+    default: false
 outputs:
   pull-request-number:
     description: 'The pull request number'

--- a/src/create-or-update-branch.ts
+++ b/src/create-or-update-branch.ts
@@ -192,6 +192,7 @@ export async function createOrUpdateBranch(
       result.action = 'created'
       core.info(`Created branch '${branch}'`)
     } else {
+      result.action = 'not-created'
       core.info(
         `Branch '${branch}' is not ahead of base '${base}' and will not be created`
       )

--- a/src/create-pull-request.ts
+++ b/src/create-pull-request.ts
@@ -30,6 +30,7 @@ export interface Inputs {
   teamReviewers: string[]
   milestone: number
   draft: boolean
+  failIfNoChanges: boolean
 }
 
 export async function createPullRequest(inputs: Inputs): Promise<void> {
@@ -178,6 +179,10 @@ export async function createPullRequest(inputs: Inputs): Promise<void> {
       inputs.addPaths
     )
     core.endGroup()
+
+    if (['not-created', 'not-updated'].includes(result.action) && inputs.failIfNoChanges) {
+        throw new Error('No changes were made. Will not continue.')
+    }
 
     if (['created', 'updated'].includes(result.action)) {
       // The branch was created or updated

--- a/src/main.ts
+++ b/src/main.ts
@@ -25,7 +25,8 @@ async function run(): Promise<void> {
       reviewers: utils.getInputAsArray('reviewers'),
       teamReviewers: utils.getInputAsArray('team-reviewers'),
       milestone: Number(core.getInput('milestone')),
-      draft: core.getInput('draft') === 'true'
+      draft: core.getInput('draft') === 'true',
+      failIfNoChanges: core.getInput('fail-if-no-changes') === 'true'
     }
     core.debug(`Inputs: ${inspect(inputs)}`)
 


### PR DESCRIPTION
Currently if this action is used and no changes have been made to the repository, the job will silently continue. This feature adds a new flag `fail-if-no-changes`, which when enabled causes the job to fail when there are no changes.