### PR TITLE
fix: add '--' to checkout command to avoid ambiguity

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -650,6 +650,8 @@ class GitCommandManager {
             else {
                 args.push(ref);
             }
+            // https://github.com/git/git/commit/a047fafc7866cc4087201e284dc1f53e8f9a32d5
+            args.push('--');
             yield this.exec(args);
         });
     }

--- a/src/git-command-manager.ts
+++ b/src/git-command-manager.ts
@@ -32,6 +32,8 @@ export class GitCommandManager {
     } else {
       args.push(ref)
     }
+    // https://github.com/git/git/commit/a047fafc7866cc4087201e284dc1f53e8f9a32d5
+    args.push('--');
     await this.exec(args)
   }
 

--- a/src/git-command-manager.ts
+++ b/src/git-command-manager.ts
@@ -33,7 +33,7 @@ export class GitCommandManager {
       args.push(ref)
     }
     // https://github.com/git/git/commit/a047fafc7866cc4087201e284dc1f53e8f9a32d5
-    args.push('--');
+    args.push('--')
     await this.exec(args)
   }
 


### PR DESCRIPTION
Hi, thank you for developing this tool!

I found it causes an error when there are a branch and a path with the same name.
As explained [here](https://github.com/git/git/commit/a047fafc7866cc4087201e284dc1f53e8f9a32d5), adding `--` can fix this problem.

I've tested this here.
Before: https://github.com/kenji-miyake/autoware-github-actions/pull/11
After: https://github.com/kenji-miyake/autoware-github-actions/pull/12

I came up with using `git switch` as another option, but I refrained from that because it could be a big change.