### PR TITLE
Document that draft status changes are not reflected

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ All inputs are **optional**. If not set, sensible defaults will be used.
 | `reviewers` | A comma or newline-separated list of reviewers (GitHub usernames) to request a review from. | |
 | `team-reviewers` | A comma or newline-separated list of GitHub teams to request a review from. Note that a `repo` scoped [PAT](https://docs.github.com/en/github/authenticating-to-github/creating-a-personal-access-token) may be required. See [this issue](https://github.com/peter-evans/create-pull-request/issues/155). If using a GitHub App, refer to [Authenticating with GitHub App generated tokens](docs/concepts-guidelines.md#authenticating-with-github-app-generated-tokens) for the proper permissions. | |
 | `milestone` | The number of the milestone to associate this pull request with. | |
-| `draft` | Create a [draft pull request](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests). | `false` |
+| `draft` | Create a [draft pull request](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests). It is not possible to change draft status after creation except through the web interface. | `false` |
 
 For self-hosted runners behind a corporate proxy set the `https_proxy` environment variable.
 ```yml

--- a/action.yml
+++ b/action.yml
@@ -69,7 +69,7 @@ inputs:
   milestone:
     description: 'The number of the milestone to associate the pull request with.'
   draft:
-    description: 'Create a draft pull request'
+    description: 'Create a draft pull request. It is not possible to change draft status after creation except through the web interface'
     default: false
 outputs:
   pull-request-number:


### PR DESCRIPTION
The github pull request update API does not accept changing
draft status - the only way to do it appears to be through
the web UI.