### PR TITLE
fix: use full name for head branch to allow for repo renaming

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -950,8 +950,11 @@ class GitHubHelper {
             repo: repo
         };
     }
-    createOrUpdate(inputs, baseRepository, headBranch) {
+    createOrUpdate(inputs, baseRepository, headRepository) {
         return __awaiter(this, void 0, void 0, function* () {
+            const [headOwner] = headRepository.split('/');
+            const headBranch = `${headOwner}:${inputs.branch}`;
+            const headBranchFull = `${headRepository}:${inputs.branch}`;
             // Try to create the pull request
             try {
                 core.info(`Attempting creation of pull request`);
@@ -974,7 +977,7 @@ class GitHubHelper {
             }
             // Update the pull request that exists for this branch and base
             core.info(`Fetching existing pull request`);
-            const { data: pulls } = yield this.octokit.rest.pulls.list(Object.assign(Object.assign({}, this.parseRepository(baseRepository)), { state: 'open', head: headBranch, base: inputs.base }));
+            const { data: pulls } = yield this.octokit.rest.pulls.list(Object.assign(Object.assign({}, this.parseRepository(baseRepository)), { state: 'open', head: headBranchFull, base: inputs.base }));
             core.info(`Attempting update of pull request`);
             const { data: pull } = yield this.octokit.rest.pulls.update(Object.assign(Object.assign({}, this.parseRepository(baseRepository)), { pull_number: pulls[0].number, title: inputs.title, body: inputs.body }));
             core.info(`Updated pull request #${pull.number} (${headBranch} => ${inputs.base})`);
@@ -996,10 +999,8 @@ class GitHubHelper {
     }
     createOrUpdatePullRequest(inputs, baseRepository, headRepository) {
         return __awaiter(this, void 0, void 0, function* () {
-            const [headOwner] = headRepository.split('/');
-            const headBranch = `${headOwner}:${inputs.branch}`;
             // Create or update the pull request
-            const pull = yield this.createOrUpdate(inputs, baseRepository, headBranch);
+            const pull = yield this.createOrUpdate(inputs, baseRepository, headRepository);
             // Apply milestone
             if (inputs.milestone) {
                 core.info(`Applying milestone '${inputs.milestone}'`);

--- a/src/github-helper.ts
+++ b/src/github-helper.ts
@@ -39,8 +39,12 @@ export class GitHubHelper {
   private async createOrUpdate(
     inputs: Inputs,
     baseRepository: string,
-    headBranch: string
+    headRepository: string
   ): Promise<Pull> {
+    const [headOwner] = headRepository.split('/')
+    const headBranch = `${headOwner}:${inputs.branch}`
+    const headBranchFull = `${headRepository}:${inputs.branch}`
+
     // Try to create the pull request
     try {
       core.info(`Attempting creation of pull request`)
@@ -76,7 +80,7 @@ export class GitHubHelper {
     const {data: pulls} = await this.octokit.rest.pulls.list({
       ...this.parseRepository(baseRepository),
       state: 'open',
-      head: headBranch,
+      head: headBranchFull,
       base: inputs.base
     })
     core.info(`Attempting update of pull request`)
@@ -113,11 +117,12 @@ export class GitHubHelper {
     baseRepository: string,
     headRepository: string
   ): Promise<Pull> {
-    const [headOwner] = headRepository.split('/')
-    const headBranch = `${headOwner}:${inputs.branch}`
-
     // Create or update the pull request
-    const pull = await this.createOrUpdate(inputs, baseRepository, headBranch)
+    const pull = await this.createOrUpdate(
+      inputs,
+      baseRepository,
+      headRepository
+    )
 
     // Apply milestone
     if (inputs.milestone) {


### PR DESCRIPTION
Fixes: https://github.com/peter-evans/create-pull-request/issues/1163

Fixes an issue that occurs when a pull request is created from a repository fork that has been renamed from its original name.