### PR TITLE
feat: add option to choose between force and force-with-lease

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -69,6 +69,9 @@ inputs:
   draft:
     description: 'Create a draft pull request. It is not possible to change draft status after creation except through the web interface'
     default: false
+  force:
+    description: 'Force push the changes even if the current branch is referenced by others.'
+    default: false
 outputs:
   pull-request-number:
     description: 'The pull request number'

--- a/dist/index.js
+++ b/dist/index.js
@@ -393,7 +393,7 @@ function createPullRequest(inputs) {
                 // The branch was created or updated
                 core.startGroup(`Pushing pull request branch to '${branchRemoteName}/${inputs.branch}'`);
                 yield git.push([
-                    '--force-with-lease',
+                    inputs.force ? '--force' : '--force-with-lease',
                     branchRemoteName,
                     `HEAD:refs/heads/${inputs.branch}`
                 ]);
@@ -1109,7 +1109,8 @@ function run() {
                 reviewers: utils.getInputAsArray('reviewers'),
                 teamReviewers: utils.getInputAsArray('team-reviewers'),
                 milestone: Number(core.getInput('milestone')),
-                draft: core.getBooleanInput('draft')
+                draft: core.getBooleanInput('draft'),
+                force: core.getBooleanInput('force')
             };
             core.debug(`Inputs: ${(0, util_1.inspect)(inputs)}`);
             yield (0, create_pull_request_1.createPullRequest)(inputs);

--- a/src/create-pull-request.ts
+++ b/src/create-pull-request.ts
@@ -30,6 +30,7 @@ export interface Inputs {
   teamReviewers: string[]
   milestone: number
   draft: boolean
+  force: boolean
 }
 
 export async function createPullRequest(inputs: Inputs): Promise<void> {
@@ -185,7 +186,7 @@ export async function createPullRequest(inputs: Inputs): Promise<void> {
         `Pushing pull request branch to '${branchRemoteName}/${inputs.branch}'`
       )
       await git.push([
-        '--force-with-lease',
+        inputs.force ? '--force' : '--force-with-lease',
         branchRemoteName,
         `HEAD:refs/heads/${inputs.branch}`
       ])

--- a/src/main.ts
+++ b/src/main.ts
@@ -25,7 +25,8 @@ async function run(): Promise<void> {
       reviewers: utils.getInputAsArray('reviewers'),
       teamReviewers: utils.getInputAsArray('team-reviewers'),
       milestone: Number(core.getInput('milestone')),
-      draft: core.getBooleanInput('draft')
+      draft: core.getBooleanInput('draft'),
+      force: core.getBooleanInput('force')
     }
     core.debug(`Inputs: ${inspect(inputs)}`)
 


### PR DESCRIPTION
When using this plugin with a build bot, the build bot (e.g. bors) creates another commit that references the PR branch.
This forbids updating the PR branch through `--force-with-lease` push option.

This PR adds a boolean option to choose between `force-with-lease` and `force`.


## Before

![image](https://user-images.githubusercontent.com/3205589/168975589-26cb5f1f-d828-4c7c-918b-e983c8c75517.png)

## After

![image](https://user-images.githubusercontent.com/3205589/168975679-882109c2-e337-43ce-bf9f-6dc9b2cef1e5.png)
