### PR TITLE
feat: add `force` option to `tryFetch`

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -62,7 +62,9 @@ exports.getWorkingBaseAndType = getWorkingBaseAndType;
 function tryFetch(git, remote, branch) {
     return __awaiter(this, void 0, void 0, function* () {
         try {
-            yield git.fetch([`${branch}:refs/remotes/${remote}/${branch}`], remote);
+            yield git.fetch([`${branch}:refs/remotes/${remote}/${branch}`], remote, [
+                '--force'
+            ]);
             return true;
         }
         catch (_a) {

--- a/src/create-or-update-branch.ts
+++ b/src/create-or-update-branch.ts
@@ -33,7 +33,9 @@ export async function tryFetch(
   branch: string
 ): Promise<boolean> {
   try {
-    await git.fetch([`${branch}:refs/remotes/${remote}/${branch}`], remote)
+    await git.fetch([`${branch}:refs/remotes/${remote}/${branch}`], remote, [
+      '--force'
+    ])
     return true
   } catch {
     return false


### PR DESCRIPTION
## The problem

Dockerized self-hosted runner (https://github.com/myoung34/docker-github-actions-runner) does not reset its local storage when a task is finished.

Thus, a newly created PR via worker#5 cannot be fetched via worker#7 because its not a fast-forward change.

This makes the later `hasDiff` logic that stops pushing if the actual content has no difference (the commit hashes are different because the commit has different `createdAt` timestamp.

[PR Log]
![image](https://user-images.githubusercontent.com/3205589/170179359-cb220d23-e067-44be-9c03-e509f088f358.png)

[Action Log]
![image](https://user-images.githubusercontent.com/3205589/170178977-4831e04f-712d-4db5-b9e6-5071442f5601.png)

[Actual diff between two consequent pushes]
![image](https://user-images.githubusercontent.com/3205589/170179322-e29cc7af-995e-43a2-a698-b0a9f1afe909.png)

## Solution

Adding force option to git.fetch will overwrite previously cached branch information.

## Justification

I found that all four `git.fetch` command in `create-or-update-branch.ts` already has the `force` option except the one changed in this PR.

## Alternatives

I may add manual `rm -rf /working/.git` command before all self-hosted actions, but the above justification makes this solution more desirable.