### PR TITLE
Support no_proxy environment variable

### DIFF
--- a/src/octokit-client.ts
+++ b/src/octokit-client.ts
@@ -11,13 +11,23 @@ export const Octokit = Core.plugin(
   autoProxyAgent
 )
 
-// Octokit plugin to support the https_proxy environment variable
+// Octokit plugin to support the https_proxy and no_proxy environment variable
 function autoProxyAgent(octokit: Core) {
   const proxy = process.env.https_proxy || process.env.HTTPS_PROXY
+
+  const noProxy = process.env.no_proxy || process.env.NO_PROXY
+  let noProxyArray: string[] = []
+  if (noProxy) {
+    noProxyArray = noProxy.split(',')
+  }
+
   if (!proxy) return
 
   const agent = new HttpsProxyAgent(proxy)
   octokit.hook.before('request', options => {
+    if (noProxyArray.includes(options.request.hostname)) {
+      return
+    }
     options.request.agent = agent
   })
 }


### PR DESCRIPTION
In our case we have self hosted runners which are managed by our enterprise. All the proxy envvars are set in the runners itself. 
And we would need the proxy if we would go to [github.com](https://github.com) but not if we use this action to create a PR in our self hosted github enterprise. 

This change will check the environment variable `no_proxy` and will only use proxy agent if the requested url is not part of this variable. Currently this only works without wildcards in the domains which are part of `no_proxy`.

Let me know if something like this is out of scope or if there should be further changes.