### PR TITLE
fix: improve default pr body text

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ All inputs are **optional**. If not set, sensible defaults will be used.
 | `base` | Sets the pull request base branch. | Defaults to the branch checked out in the workflow. |
 | `push-to-fork` | A fork of the checked-out parent repository to which the pull request branch will be pushed. e.g. `owner/repo-fork`. The pull request will be created to merge the fork's branch into the parent's base. See [push pull request branches to a fork](docs/concepts-guidelines.md#push-pull-request-branches-to-a-fork) for details. | |
 | `title` | The title of the pull request. | `Changes by create-pull-request action` |
-| `body` | The body of the pull request. | `Automated changes by [create-pull-request](https://github.com/peter-evans/create-pull-request) GitHub action` |
+| `body` | The body of the pull request. | `Automated changes by [create-pull-request](https://github.com/peter-evans/create-pull-request) GitHub Action.` |
 | `labels` | A comma or newline-separated list of labels. | |
 | `assignees` | A comma or newline-separated list of assignees (GitHub usernames). | |
 | `reviewers` | A comma or newline-separated list of reviewers (GitHub usernames) to request a review from. | |

--- a/action.yml
+++ b/action.yml
@@ -53,7 +53,7 @@ inputs:
     default: 'Changes by create-pull-request action'
   body:
     description: 'The body of the pull request.'
-    default: 'Automated changes by [create-pull-request](https://github.com/peter-evans/create-pull-request) GitHub action'
+    default: 'Automated changes by [create-pull-request](https://github.com/peter-evans/create-pull-request) GitHub Action.'
   labels:
     description: 'A comma or newline separated list of labels.'
   assignees:


### PR DESCRIPTION
## Changes:

- Capitalize proper noun GitHub Actions
- End sentence with a full stop `.`

## Context:

Fixing up the default PR body text that comes with this action.