### PR TITLE
fix: only strip optional '.git' suffix from https server remote name and not 'Xgit'

### DIFF
--- a/__test__/utils.unit.test.ts
+++ b/__test__/utils.unit.test.ts
@@ -56,6 +56,24 @@ describe('utils tests', () => {
     )
     expect(remote4.protocol).toEqual('HTTPS')
     expect(remote4.repository).toEqual('peter-evans/create-pull-request')
+
+    const remote5 = utils.getRemoteDetail(
+      'https://github.com/peter-evans/ungit'
+    )
+    expect(remote5.protocol).toEqual('HTTPS')
+    expect(remote5.repository).toEqual('peter-evans/ungit')
+
+    const remote6 = utils.getRemoteDetail(
+      'https://github.com/peter-evans/ungit.git'
+    )
+    expect(remote6.protocol).toEqual('HTTPS')
+    expect(remote6.repository).toEqual('peter-evans/ungit')
+
+    const remote7 = utils.getRemoteDetail(
+      'git@github.com:peter-evans/ungit.git'
+    )
+    expect(remote7.protocol).toEqual('SSH')
+    expect(remote7.repository).toEqual('peter-evans/ungit')
   })
 
   test('getRemoteDetail fails to parse a remote URL', async () => {

--- a/dist/index.js
+++ b/dist/index.js
@@ -1230,8 +1230,8 @@ function getRemoteDetail(remoteUrl) {
     if (!githubServerMatch) {
         throw new Error('Could not parse GitHub Server name');
     }
-    const httpsUrlPattern = new RegExp('^https?://.*@?' + githubServerMatch[1] + '/(.+/.+?)(.git)?$', 'i');
-    const sshUrlPattern = new RegExp('^git@' + githubServerMatch[1] + ':(.+/.+).git$', 'i');
+    const httpsUrlPattern = new RegExp('^https?://.*@?' + githubServerMatch[1] + '/(.+/.+?)(\\.git)?$', 'i');
+    const sshUrlPattern = new RegExp('^git@' + githubServerMatch[1] + ':(.+/.+)\\.git$', 'i');
     const httpsMatch = remoteUrl.match(httpsUrlPattern);
     if (httpsMatch) {
         return {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -47,11 +47,11 @@ export function getRemoteDetail(remoteUrl: string): RemoteDetail {
   }
 
   const httpsUrlPattern = new RegExp(
-    '^https?://.*@?' + githubServerMatch[1] + '/(.+/.+?)(.git)?$',
+    '^https?://.*@?' + githubServerMatch[1] + '/(.+/.+?)(\\.git)?$',
     'i'
   )
   const sshUrlPattern = new RegExp(
-    '^git@' + githubServerMatch[1] + ':(.+/.+).git$',
+    '^git@' + githubServerMatch[1] + ':(.+/.+)\\.git$',
     'i'
   )
 


### PR DESCRIPTION
By escaping the `.` in the regex.

I think the bug got introduced by https://github.com/peter-evans/create-pull-request/pull/1153

Fixes #1256