### PR TITLE
bugfix(#1267): use baseUrl for no-proxy determination

### DIFF
--- a/src/octokit-client.ts
+++ b/src/octokit-client.ts
@@ -25,7 +25,7 @@ function autoProxyAgent(octokit: Core) {
 
   const agent = new HttpsProxyAgent(proxy)
   octokit.hook.before('request', options => {
-    if (noProxyArray.includes(options.request.hostname)) {
+    if (noProxyArray.includes(options.request.hostname) || noProxyArray.includes( new URL(options.baseUrl).host) {
       return
     }
     options.request.agent = agent


### PR DESCRIPTION
Fixes https://github.com/peter-evans/create-pull-request/issues/1267

When a PR is raised, the request.hostname is not set, so comes can't be found within the noProxyArray.

However the various PR helpers, have the baseUrl parameter set, so use that to determine if we should use the proxy or not.