### PR TITLE
chore: replace issue template with issue form

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,7 +1,0 @@
-### Subject of the issue
-
-Describe your issue here.
-
-### Steps to reproduce
-
-If this issue is describing a possible bug please provide (or link to) your GitHub Actions workflow.

--- a/.github/ISSUE_TEMPLATE/issue-report.yml
+++ b/.github/ISSUE_TEMPLATE/issue-report.yml
@@ -1,0 +1,16 @@
+name: Issue report
+description: Report an issue
+body:
+  - type: textarea
+    attributes:
+      label: Subject of the issue
+      description: "Describe your issue here."
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Steps to reproduce
+      description: "If this issue is describing a possible bug please provide (or link to) your GitHub Actions workflow."
+    validations:
+      required: true


### PR DESCRIPTION
## Changes:

- Replace issue _template_ with issue _form_:
  - No more missed fields: users _must_ fill out both fields before they can submit the issue
  - What the user needs to do is now explained next to the input field
  - No more messing up the layout/markdown when filling out the form

## Context:

You can preview the new form by going to: [the `issue-report.yml` file on my fork's branch](https://github.com/HonkingGoose/create-pull-request/blob/refactor/replace-issue-template-with-forms/.github/ISSUE_TEMPLATE/issue-report.yml).

## Docs:

- [GitHub Docs, syntax for issue forms](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-issue-forms)
- [GitHub Docs, syntax for GitHub's form schema](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-githubs-form-schema)