### PR TITLE
add no-verify option

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -69,6 +69,9 @@ inputs:
   draft:
     description: 'Create a draft pull request. It is not possible to change draft status after creation except through the web interface'
     default: false
+  no-verify:
+    description: 'Do not run pre-push steps when pushing'
+    default: false
 outputs:
   pull-request-number:
     description: 'The pull request number'

--- a/dist/index.js
+++ b/dist/index.js
@@ -423,11 +423,15 @@ function createPullRequest(inputs) {
             if (['created', 'updated'].includes(result.action)) {
                 // The branch was created or updated
                 core.startGroup(`Pushing pull request branch to '${branchRemoteName}/${inputs.branch}'`);
-                yield git.push([
+                let push_args = [
                     '--force-with-lease',
                     branchRemoteName,
                     `HEAD:refs/heads/${inputs.branch}`
-                ]);
+                ];
+                if (inputs.no_verify) {
+                    push_args.push('--no-verify');
+                }
+                yield git.push(push_args);
                 core.endGroup();
             }
             // Set the base. It would have been '' if not specified as an input
@@ -1141,7 +1145,8 @@ function run() {
                 reviewers: utils.getInputAsArray('reviewers'),
                 teamReviewers: utils.getInputAsArray('team-reviewers'),
                 milestone: Number(core.getInput('milestone')),
-                draft: core.getBooleanInput('draft')
+                draft: core.getBooleanInput('draft'),
+                no_verify: core.getBooleanInput('no-verify'),
             };
             core.debug(`Inputs: ${(0, util_1.inspect)(inputs)}`);
             yield (0, create_pull_request_1.createPullRequest)(inputs);

--- a/src/create-pull-request.ts
+++ b/src/create-pull-request.ts
@@ -30,6 +30,7 @@ export interface Inputs {
   teamReviewers: string[]
   milestone: number
   draft: boolean
+  no_verify: boolean
 }
 
 export async function createPullRequest(inputs: Inputs): Promise<void> {
@@ -192,11 +193,15 @@ export async function createPullRequest(inputs: Inputs): Promise<void> {
       core.startGroup(
         `Pushing pull request branch to '${branchRemoteName}/${inputs.branch}'`
       )
-      await git.push([
+      let push_args = [
         '--force-with-lease',
         branchRemoteName,
         `HEAD:refs/heads/${inputs.branch}`
-      ])
+      ]
+      if (inputs.no_verify) {
+        push_args.push('--no-verify')
+      }
+      await git.push(push_args)
       core.endGroup()
     }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -25,7 +25,8 @@ async function run(): Promise<void> {
       reviewers: utils.getInputAsArray('reviewers'),
       teamReviewers: utils.getInputAsArray('team-reviewers'),
       milestone: Number(core.getInput('milestone')),
-      draft: core.getBooleanInput('draft')
+      draft: core.getBooleanInput('draft'),
+      no_verify: core.getBooleanInput('no-verify'),
     }
     core.debug(`Inputs: ${inspect(inputs)}`)
 


### PR DESCRIPTION
This optionally adds `--no-verify` when doing `git push`. I had some issues getting around a `pre-push` hook configured in a repository.
I think it would also be useful in certain situations for `git commit` but I couldn't easily find the places where `git commit` is invoked.