### PR TITLE
fix: pull changes from temporary branch

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -190,7 +190,7 @@ function createOrUpdateBranch(git, commitMessage, base, branch, branchRemoteName
             yield git.fetch([`${base}:${base}`], baseRemote, ['--force']);
             yield git.checkout(base);
             // Cherrypick commits from the temporary branch starting from the working base
-            const commits = yield git.revList([`${workingBase}..${tempBranch}`, '.'], ['--reverse']);
+            const commits = yield git.revList([`${base}..${tempBranch}`, '.'], ['--reverse']);
             for (const commit of splitLines(commits)) {
                 const result = yield git.cherryPick(['--strategy=recursive', '--strategy-option=theirs', commit], true);
                 if (result.exitCode != 0 && !result.stderr.includes(CHERRYPICK_EMPTY)) {

--- a/src/create-or-update-branch.ts
+++ b/src/create-or-update-branch.ts
@@ -195,7 +195,7 @@ export async function createOrUpdateBranch(
     await git.checkout(base)
     // Cherrypick commits from the temporary branch starting from the working base
     const commits = await git.revList(
-      [`${workingBase}..${tempBranch}`, '.'],
+      [`${base}..${tempBranch}`, '.'],
       ['--reverse']
     )
     for (const commit of splitLines(commits)) {


### PR DESCRIPTION
The temporary branch is created from the working base branch. So the differences between the two branches will always be none. What we want is all the differences from temporary branch to the base branch.

This should fix #1828