### PR TITLE
Update github-actions[bot] and author email format

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,8 +68,8 @@ jobs:
         uses: ./
         with:
           commit-message: '[CI] test ${{ matrix.target }}'
-          committer: GitHub <noreply@github.com>
           author: ${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>
+          committer: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
           title: '[CI] test ${{ matrix.target }}'
           body: |
             - CI test case for target '${{ matrix.target }}'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,8 +68,8 @@ jobs:
         uses: ./
         with:
           commit-message: '[CI] test ${{ matrix.target }}'
-          author: ${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>
           committer: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
+          author: ${{ github.actor }} <${{ github.actor_id }}+${{ github.actor }}@users.noreply.github.com>
           title: '[CI] test ${{ matrix.target }}'
           body: |
             - CI test case for target '${{ matrix.target }}'

--- a/.github/workflows/cpr-example-command.yml
+++ b/.github/workflows/cpr-example-command.yml
@@ -16,8 +16,8 @@ jobs:
         uses: ./
         with:
           commit-message: Update report
-          author: ${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>
           committer: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
+          author: ${{ github.actor }} <${{ github.actor_id }}+${{ github.actor }}@users.noreply.github.com>
           signoff: false
           title: '[Example] Update report'
           body: |

--- a/.github/workflows/cpr-example-command.yml
+++ b/.github/workflows/cpr-example-command.yml
@@ -16,8 +16,8 @@ jobs:
         uses: ./
         with:
           commit-message: Update report
-          committer: GitHub <noreply@github.com>
           author: ${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>
+          committer: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
           signoff: false
           title: '[Example] Update report'
           body: |

--- a/README.md
+++ b/README.md
@@ -55,8 +55,8 @@ All inputs are **optional**. If not set, sensible defaults will be used.
 | `path` | Relative path under `GITHUB_WORKSPACE` to the repository. | `GITHUB_WORKSPACE` |
 | `add-paths` | A comma or newline-separated list of file paths to commit. Paths should follow git's [pathspec](https://git-scm.com/docs/gitglossary#Documentation/gitglossary.txt-aiddefpathspecapathspec) syntax. If no paths are specified, all new and modified files are added. See [Add specific paths](#add-specific-paths). | |
 | `commit-message` | The message to use when committing changes. | `[create-pull-request] automated change` |
-| `committer` | The committer name and email address in the format `Display Name <email@address.com>`. Defaults to the GitHub Actions bot user. | `GitHub <noreply@github.com>` |
 | `author` | The author name and email address in the format `Display Name <email@address.com>`. Defaults to the user who triggered the workflow run. | `${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>` |
+| `committer` | The committer name and email address in the format `Display Name <email@address.com>`. Defaults to the GitHub Actions bot user. | `github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>` |
 | `signoff` | Add [`Signed-off-by`](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) line by the committer at the end of the commit log message. | `false` |
 | `branch` | The pull request branch name. | `create-pull-request/patch` |
 | `delete-branch` | Delete the `branch` when closing pull requests, and when undeleted after merging. | `false` |
@@ -235,8 +235,8 @@ jobs:
         with:
           token: ${{ secrets.PAT }}
           commit-message: Update report
-          committer: GitHub <noreply@github.com>
           author: ${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>
+          committer: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
           signoff: false
           branch: example-patches
           delete-branch: true

--- a/README.md
+++ b/README.md
@@ -55,8 +55,8 @@ All inputs are **optional**. If not set, sensible defaults will be used.
 | `path` | Relative path under `GITHUB_WORKSPACE` to the repository. | `GITHUB_WORKSPACE` |
 | `add-paths` | A comma or newline-separated list of file paths to commit. Paths should follow git's [pathspec](https://git-scm.com/docs/gitglossary#Documentation/gitglossary.txt-aiddefpathspecapathspec) syntax. If no paths are specified, all new and modified files are added. See [Add specific paths](#add-specific-paths). | |
 | `commit-message` | The message to use when committing changes. | `[create-pull-request] automated change` |
-| `author` | The author name and email address in the format `Display Name <email@address.com>`. Defaults to the user who triggered the workflow run. | `${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>` |
 | `committer` | The committer name and email address in the format `Display Name <email@address.com>`. Defaults to the GitHub Actions bot user. | `github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>` |
+| `author` | The author name and email address in the format `Display Name <email@address.com>`. Defaults to the user who triggered the workflow run. | `${{ github.actor }} <${{ github.actor_id }}+${{ github.actor }}@users.noreply.github.com>` |
 | `signoff` | Add [`Signed-off-by`](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) line by the committer at the end of the commit log message. | `false` |
 | `branch` | The pull request branch name. | `create-pull-request/patch` |
 | `delete-branch` | Delete the `branch` when closing pull requests, and when undeleted after merging. | `false` |
@@ -235,8 +235,8 @@ jobs:
         with:
           token: ${{ secrets.PAT }}
           commit-message: Update report
-          author: ${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>
           committer: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
+          author: ${{ github.actor }} <${{ github.actor_id }}+${{ github.actor }}@users.noreply.github.com>
           signoff: false
           branch: example-patches
           delete-branch: true

--- a/action.yml
+++ b/action.yml
@@ -25,7 +25,7 @@ inputs:
     description: >
       The author name and email address in the format `Display Name <email@address.com>`.
       Defaults to the user who triggered the workflow run.
-    default: '${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>'
+    default: '${{ github.actor }} <${{ github.actor_id }}+${{ github.actor }}@users.noreply.github.com>'
   signoff:
     description: 'Add `Signed-off-by` line by the committer at the end of the commit log message.'
     default: false

--- a/action.yml
+++ b/action.yml
@@ -20,7 +20,7 @@ inputs:
     description: >
       The committer name and email address in the format `Display Name <email@address.com>`.
       Defaults to the GitHub Actions bot user.
-    default: 'GitHub <noreply@github.com>'
+    default: 'github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>'
   author:
     description: >
       The author name and email address in the format `Display Name <email@address.com>`.


### PR DESCRIPTION
The noreply email address for GitHub accounts since July 18, 2017, contain an ID number and the username in the form of [ID+USERNAME@users.noreply.github.com](mailto:ID+USERNAME@users.noreply.github.com) (the documentation on it is [here](https://docs.github.com/en/account-and-profile/setting-up-and-managing-your-personal-account-on-github/managing-email-preferences/setting-your-commit-email-address)).

When any action happens in a workflow, it happens in the name of the the [github-actions[bot]](https://api.github.com/users/github-actions%5Bbot%5D) user, which was created on 2018-07-30T09:30:16Z, a year after they started using their new format.

This PR should incorporate both of these changes, and unify the behaviour.