### PR TITLE
fix(test): use gitignore for untracked files in tests

### DIFF
--- a/__test__/create-or-update-branch.int.test.ts
+++ b/__test__/create-or-update-branch.int.test.ts
@@ -27,7 +27,7 @@ const FORK_REMOTE_NAME = 'fork'
 
 const ADD_PATHS_DEFAULT = []
 const ADD_PATHS_MULTI = ['a', 'b']
-const ADD_PATHS_WILDCARD = ['a/*.txt', 'b/*.txt']
+const ADD_PATHS_WILDCARD = ['a/*.txt']
 
 async function createFile(filename: string, content?: string): Promise<string> {
   const _content = content ? content : uuidv4()
@@ -297,11 +297,9 @@ describe('create-or-update-branch tests', () => {
       ADD_PATHS_DEFAULT
     )
     await git.checkout(BRANCH)
-    expect(result.action).toEqual('created')
+    expect(result.action).toEqual('none')
     expect(await getFileContent(UNTRACKED_FILE)).toEqual(untrackedContent)
-    expect(
-      await gitLogMatches([commitMessage, INIT_COMMIT_MESSAGE])
-    ).toBeTruthy()
+    expect(await gitLogMatches([INIT_COMMIT_MESSAGE])).toBeTruthy()
 
     // Push pull request branch to remote
     await git.push([
@@ -326,12 +324,10 @@ describe('create-or-update-branch tests', () => {
       ADD_PATHS_DEFAULT
     )
     await git.checkout(BRANCH)
-    expect(_result.action).toEqual('updated')
-    expect(_result.hasDiffWithBase).toBeTruthy()
+    expect(_result.action).toEqual('not-updated')
+    expect(_result.hasDiffWithBase).toBeFalsy()
     expect(await getFileContent(UNTRACKED_FILE)).toEqual(_untrackedContent)
-    expect(
-      await gitLogMatches([_commitMessage, INIT_COMMIT_MESSAGE])
-    ).toBeTruthy()
+    expect(await gitLogMatches([INIT_COMMIT_MESSAGE])).toBeTruthy()
   })
 
   it('tests create and update with identical changes', async () => {
@@ -1182,11 +1178,9 @@ describe('create-or-update-branch tests', () => {
       await gitLogMatches([commitMessage, INIT_COMMIT_MESSAGE])
     ).toBeTruthy()
     await git.checkout(BRANCHB)
-    expect(resultB.action).toEqual('created')
+    expect(resultB.action).toEqual('none')
     expect(await getFileContent(UNTRACKED_FILE)).toEqual(changes.untracked)
-    expect(
-      await gitLogMatches([commitMessage, INIT_COMMIT_MESSAGE])
-    ).toBeTruthy()
+    expect(await gitLogMatches([INIT_COMMIT_MESSAGE])).toBeTruthy()
 
     // Delete the local branches
     await git.checkout(DEFAULT_BRANCH)
@@ -1289,11 +1283,9 @@ describe('create-or-update-branch tests', () => {
       ADD_PATHS_DEFAULT
     )
     await git.checkout(BRANCH)
-    expect(result.action).toEqual('created')
+    expect(result.action).toEqual('none')
     expect(await getFileContent(UNTRACKED_FILE)).toEqual(untrackedContent)
-    expect(
-      await gitLogMatches([commitMessage, INIT_COMMIT_MESSAGE])
-    ).toBeTruthy()
+    expect(await gitLogMatches([INIT_COMMIT_MESSAGE])).toBeTruthy()
 
     // Push pull request branch to remote
     await git.push([
@@ -1321,12 +1313,10 @@ describe('create-or-update-branch tests', () => {
       ADD_PATHS_DEFAULT
     )
     await git.checkout(BRANCH)
-    expect(_result.action).toEqual('updated')
-    expect(_result.hasDiffWithBase).toBeTruthy()
+    expect(_result.action).toEqual('not-updated')
+    expect(_result.hasDiffWithBase).toBeFalsy()
     expect(await getFileContent(UNTRACKED_FILE)).toEqual(_untrackedContent)
-    expect(
-      await gitLogMatches([_commitMessage, INIT_COMMIT_MESSAGE])
-    ).toBeTruthy()
+    expect(await gitLogMatches([INIT_COMMIT_MESSAGE])).toBeTruthy()
   })
 
   it('tests create and update with identical changes (WBNB)', async () => {
@@ -2213,11 +2203,9 @@ describe('create-or-update-branch tests', () => {
       await gitLogMatches([commitMessage, INIT_COMMIT_MESSAGE])
     ).toBeTruthy()
     await git.checkout(BRANCHB)
-    expect(resultB.action).toEqual('created')
+    expect(resultB.action).toEqual('none')
     expect(await getFileContent(UNTRACKED_FILE)).toEqual(changes.untracked)
-    expect(
-      await gitLogMatches([commitMessage, INIT_COMMIT_MESSAGE])
-    ).toBeTruthy()
+    expect(await gitLogMatches([INIT_COMMIT_MESSAGE])).toBeTruthy()
 
     // Delete the local branches
     await git.checkout(DEFAULT_BRANCH)

--- a/__test__/entrypoint.sh
+++ b/__test__/entrypoint.sh
@@ -20,6 +20,7 @@ cd /git/local/test-base
 git config --global user.email "you@example.com"
 git config --global user.name "Your Name"
 echo "#test-base" > README.md
+echo "b/" > .gitignore
 git add .
 git commit -m "initial commit"
 git push -u


### PR DESCRIPTION
## Description

I am impressed by the test infrastructure you've build to test git related task in this repo.
IMHO there is a small issue with that:
Currently also untracked files are considered in all tests but also committed.

## Changes

This should not be the case - therefore I've added the directory `b/` (because of the [`UNTRACKED_FILE`](https://github.com/peter-evans/create-pull-request/blob/eebb6ccce1e609378f84426acf60c49144cf2d3a/__test__/create-or-update-branch.int.test.ts#L15)) to the `.gitignore` inside the test infrastructure (see entrypoint).

Due this change also the expected values of some tests need reconsideration.

### Wildcard

Even the `ADD_PATHS_WILDCARD` needs to drop the `'b/*.txt'` file because otherwise git would exit with code 1.

Another option here could be to catch the error message within the code:

> The following paths are ignored by one of your .gitignore files:
> b

see here:

https://github.com/peter-evans/create-pull-request/blob/eebb6ccce1e609378f84426acf60c49144cf2d3a/src/create-or-update-branch.ts#L212-L214

If you want me to change that let me know.

<hr />

Marco Lecheler [marco.lecheler@mercedes-benz.com](mailto:marco.lecheler@mercedes-benz.com) Mercedes-Benz Tech Innovation GmbH ([ProviderInformation](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md))