### PR TITLE
Update action runtime to node 20

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.x
+          node-version: 20.x
           cache: npm
       - run: npm ci
       - run: npm run build

--- a/action.yml
+++ b/action.yml
@@ -81,7 +81,7 @@ outputs:
   pull-request-head-sha:
     description: 'The commit SHA of the pull request branch.'
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'dist/index.js'
 branding:
   icon: 'git-pull-request'


### PR DESCRIPTION
Similar to #1074 but this time upgrading the Node.js runtime from v16 to v20. Note that Node.js v16 will be end of life on 11 Sep 2023, so GitHub will probably deprecate it around that time for Actions as well.

It might make sense to combine this upgrade with a bump from `actions/checkout@v3` to `actions/checkout@v4` because it also bumped the Node.js runtime from v16 to v20. Other actions (relevant: `peter-evans/create-or-update-project-card`, `actions/setup-node`, `actions/upload-artifact`, `actions/download-artifact`, `peter-evans/find-comment`, `peter-evans/create-or-update-comment`, `peter-evans/slash-command-dispatch`, `actions/setup-java`[^1], `peter-evans/repository-dispatch`) used/mentioned here do not seem be upgraded yet, except for [`tibdex/github-app-token@v2`](https://github.com/tibdex/github-app-token) and [`crazy-max/ghaction-import-gpg@v6`](https://github.com/crazy-max/ghaction-import-gpg) (as of writing).

[^1]: this one is [listed as `@v2` currently](https://github.com/peter-evans/create-pull-request/blob/a05bf394bea84a3b732877fcc92a5fa7a09069c3/docs/examples.md?plain=1#L209) while the latest release as of writing is [v3](https://github.com/actions/setup-java/releases/tag/v3.12.0).