### PR TITLE
Use checkout v4

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Create Pull Request action will:
 ## Usage
 
 ```yml
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       # Make changes to pull request here
 


### PR DESCRIPTION
https://github.com/actions/checkout/releases/tag/v4.1.1
checkout v4 is already released, so if there's no specific reason we should use that.