### PR TITLE
Use nodejs 20

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -81,7 +81,7 @@ outputs:
   pull-request-head-sha:
     description: 'The commit SHA of the pull request branch.'
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'dist/index.js'
 branding:
   icon: 'git-pull-request'


### PR DESCRIPTION
Node 16 has reached its end of life

More details here: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/
