### PR TITLE
Update git.fetch calls to use depth=1

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -68,7 +68,8 @@ function tryFetch(git, remote, branch) {
     return __awaiter(this, void 0, void 0, function* () {
         try {
             yield git.fetch([`${branch}:refs/remotes/${remote}/${branch}`], remote, [
-                '--force'
+                '--force',
+                '--depth=1'
             ]);
             return true;
         }
@@ -184,7 +185,7 @@ function createOrUpdateBranch(git, commitMessage, base, branch, branchRemoteName
         if (workingBase != base) {
             core.info(`Rebasing commits made to ${workingBaseType} '${workingBase}' on to base branch '${base}'`);
             // Checkout the actual base
-            yield git.fetch([`${base}:${base}`], baseRemote, ['--force']);
+            yield git.fetch([`${base}:${base}`], baseRemote, ['--force', '--depth=1']);
             yield git.checkout(base);
             // Cherrypick commits from the temporary branch starting from the working base
             const commits = yield git.revList([`${workingBase}..${tempBranch}`, '.'], ['--reverse']);
@@ -197,7 +198,7 @@ function createOrUpdateBranch(git, commitMessage, base, branch, branchRemoteName
             // Reset the temp branch to the working index
             yield git.checkout(tempBranch, 'HEAD');
             // Reset the base
-            yield git.fetch([`${base}:${base}`], baseRemote, ['--force']);
+            yield git.fetch([`${base}:${base}`], baseRemote, ['--force', '--depth=1']);
         }
         // Try to fetch the pull request branch
         if (!(yield tryFetch(git, branchRemoteName, branch))) {

--- a/dist/index.js
+++ b/dist/index.js
@@ -68,8 +68,7 @@ function tryFetch(git, remote, branch) {
     return __awaiter(this, void 0, void 0, function* () {
         try {
             yield git.fetch([`${branch}:refs/remotes/${remote}/${branch}`], remote, [
-                '--force',
-                '--depth=1'
+                '--force'
             ]);
             return true;
         }

--- a/src/create-or-update-branch.ts
+++ b/src/create-or-update-branch.ts
@@ -35,7 +35,8 @@ export async function tryFetch(
 ): Promise<boolean> {
   try {
     await git.fetch([`${branch}:refs/remotes/${remote}/${branch}`], remote, [
-      '--force'
+      '--force',
+      '--depth=1'
     ])
     return true
   } catch {
@@ -200,7 +201,7 @@ export async function createOrUpdateBranch(
       `Rebasing commits made to ${workingBaseType} '${workingBase}' on to base branch '${base}'`
     )
     // Checkout the actual base
-    await git.fetch([`${base}:${base}`], baseRemote, ['--force'])
+    await git.fetch([`${base}:${base}`], baseRemote, ['--force', '--depth=1'])
     await git.checkout(base)
     // Cherrypick commits from the temporary branch starting from the working base
     const commits = await git.revList(
@@ -219,7 +220,7 @@ export async function createOrUpdateBranch(
     // Reset the temp branch to the working index
     await git.checkout(tempBranch, 'HEAD')
     // Reset the base
-    await git.fetch([`${base}:${base}`], baseRemote, ['--force'])
+    await git.fetch([`${base}:${base}`], baseRemote, ['--force', '--depth=1'])
   }
 
   // Try to fetch the pull request branch

--- a/src/create-or-update-branch.ts
+++ b/src/create-or-update-branch.ts
@@ -35,8 +35,7 @@ export async function tryFetch(
 ): Promise<boolean> {
   try {
     await git.fetch([`${branch}:refs/remotes/${remote}/${branch}`], remote, [
-      '--force',
-      '--depth=1'
+      '--force'
     ])
     return true
   } catch {


### PR DESCRIPTION
This works for me locally, but I am not sure of the total implications to other use-cases. I explicitly didn't update the push to fork use-case when mentioned it's not supported.

![image](https://github.com/peter-evans/create-pull-request/assets/471903/c6b96d2f-f22e-4bae-9b27-d56e11673fd4)

For me, it went from 18+ minutes -> 7s. YMMV

Fixes https://github.com/peter-evans/create-pull-request/issues/2809