### PR TITLE
docs: correct suggestion for bot setup

### DIFF
--- a/docs/concepts-guidelines.md
+++ b/docs/concepts-guidelines.md
@@ -303,7 +303,7 @@ GitHub App generated tokens can be configured with fine-grained permissions and 
     - Uncheck `Active` under `Webhook`. You do not need to enter a `Webhook URL`.
     - Under `Repository permissions: Contents` select `Access: Read & write`.
     - Under `Repository permissions: Pull requests` select `Access: Read & write`.
-    - Under `Repository permissions: Workflows` select `Access: Read-only`.
+    - Under `Repository permissions: Workflows` select `Access: Read & write`.
       - **NOTE**: Only needed if pull requests could contain changes to Actions workflows.
     - Under `Organization permissions: Members` select `Access: Read-only`.
       - **NOTE**: Only needed if you would like add teams as reviewers to PRs.


### PR DESCRIPTION
The option suggested here (Read only) is not an option, and wouldn't mean/do anything - you can read these files if you have access to the repo files. The description says this is needed if the PR could change the workflow files, so you need "Read and Write". Pretty sure this is just a typo, copied from the line below instead of the line above.

Someone else notices this, and I just did too.