### PR TITLE
chore: don't bundle undici

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,9 +15,9 @@
         "@octokit/plugin-paginate-rest": "^11.3.5",
         "@octokit/plugin-rest-endpoint-methods": "^13.2.6",
         "@octokit/plugin-throttling": "^9.3.2",
+        "node-fetch-native": "^1.6.4",
         "p-limit": "^6.1.0",
         "proxy-from-env": "^1.1.0",
-        "undici": "^6.20.1",
         "uuid": "^9.0.1"
       },
       "devDependencies": {
@@ -38,7 +38,8 @@
         "js-yaml": "^4.1.0",
         "prettier": "^3.3.3",
         "ts-jest": "^29.2.5",
-        "typescript": "^5.6.3"
+        "typescript": "^5.6.3",
+        "undici": "^6.20.1"
       }
     },
     "node_modules/@actions/core": {
@@ -6282,6 +6283,12 @@
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true
     },
+    "node_modules/node-fetch-native": {
+      "version": "1.6.4",
+      "resolved": "https://registry.npmjs.org/node-fetch-native/-/node-fetch-native-1.6.4.tgz",
+      "integrity": "sha512-IhOigYzAKHd244OC0JIMIUrjzctirCmPkaIfhDeGcEETWof5zKYUW7e7MYvChGWh/4CJeXEgsRyGzuF334rOOQ==",
+      "license": "MIT"
+    },
     "node_modules/node-int64": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
@@ -7780,6 +7787,8 @@
       "version": "6.20.1",
       "resolved": "https://registry.npmjs.org/undici/-/undici-6.20.1.tgz",
       "integrity": "sha512-AjQF1QsmqfJys+LXfGTNum+qw4S88CojRInG/6t31W/1fk6G59s92bnAvGz5Cmur+kQv2SURXEvvudLmbrE8QA==",
+      "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=18.17"
       }

--- a/package.json
+++ b/package.json
@@ -35,9 +35,9 @@
     "@octokit/plugin-paginate-rest": "^11.3.5",
     "@octokit/plugin-rest-endpoint-methods": "^13.2.6",
     "@octokit/plugin-throttling": "^9.3.2",
+    "node-fetch-native": "^1.6.4",
     "p-limit": "^6.1.0",
     "proxy-from-env": "^1.1.0",
-    "undici": "^6.20.1",
     "uuid": "^9.0.1"
   },
   "devDependencies": {
@@ -58,6 +58,7 @@
     "js-yaml": "^4.1.0",
     "prettier": "^3.3.3",
     "ts-jest": "^29.2.5",
-    "typescript": "^5.6.3"
+    "typescript": "^5.6.3",
+    "undici": "^6.20.1"
   }
 }

--- a/src/octokit-client.ts
+++ b/src/octokit-client.ts
@@ -4,7 +4,7 @@ import {paginateRest} from '@octokit/plugin-paginate-rest'
 import {restEndpointMethods} from '@octokit/plugin-rest-endpoint-methods'
 import {throttling} from '@octokit/plugin-throttling'
 import {getProxyForUrl} from 'proxy-from-env'
-import {ProxyAgent, fetch as undiciFetch} from 'undici'
+import {createFetch} from 'node-fetch-native/proxy'
 export {RestEndpointMethodTypes} from '@octokit/plugin-rest-endpoint-methods'
 // eslint-disable-next-line import/no-unresolved
 export {OctokitOptions} from '@octokit/core/dist-types/types'
@@ -33,23 +33,12 @@ export const throttleOptions = {
   }
 }
 
-const proxyFetch =
-  (proxyUrl: string): typeof undiciFetch =>
-  (url, opts) => {
-    return undiciFetch(url, {
-      ...opts,
-      dispatcher: new ProxyAgent({
-        uri: proxyUrl
-      })
-    })
-  }
-
 // Octokit plugin to support the standard environment variables http_proxy, https_proxy and no_proxy
 function autoProxyAgent(octokit: OctokitCore) {
   octokit.hook.before('request', options => {
     const proxy = getProxyForUrl(options.baseUrl)
     if (proxy) {
-      options.request.fetch = proxyFetch(proxy)
+      options.request.fetch = createFetch(proxy)
     }
   })
 }


### PR DESCRIPTION
`undici` is already provided by Node.js, so we don't need to bundle our own version of it. Use the `node-native-fetch` library, which takes care of this and has battle-tested proxy-handling code.

before:
2107kB  dist/index.js
62484 lines

after:
1812kB  dist/index.js
36063 lines