### PR TITLE
docs(README): clarify that an existing open PR is managed

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,8 @@ Create Pull Request action will:
    - tracked (modified) files
    - commits made during the workflow that have not been pushed
 2. Commit all changes to a new branch, or update an existing pull request branch.
-3. Create a pull request to merge the new branch into the base&mdash;the branch checked out in the workflow.
+3. Create a pull request to merge the new branch into the base&mdash;the branch checked out in the workflow&mdash;,
+   or update an existing open pull request for that branch.
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Create Pull Request action will:
    - tracked (modified) files
    - commits made during the workflow that have not been pushed
 2. Commit all changes to a new branch, or update an existing pull request branch.
-3. Create a pull request to merge the new branch into the base&mdash;the branch checked out in the workflow&mdash;,
+3. Create or update a pull request to merge the branch into the base&mdash;the branch checked out in the workflow.
    or update an existing open pull request for that branch.
 
 ## Documentation


### PR DESCRIPTION
I was confused by the README, because it mentioned _updating an existing branch_, but not updating an existing _pull request_. Obviously, it doesn't make sense for the action to create a new PR even if there is an existing open PR, but I figure it's better to be explicit upfront in the README.