### PR TITLE
docs: note `push-to-repo` classic PAT `workflow` scope requirement

### DIFF
--- a/docs/concepts-guidelines.md
+++ b/docs/concepts-guidelines.md
@@ -231,7 +231,7 @@ It will use their own fork to push code and create the pull request.
 
 1. Create a new GitHub user and login.
 2. Fork the repository that you will be creating pull requests in.
-3. Create a Classic [Personal Access Token (PAT)](https://docs.github.com/en/github/authenticating-to-github/creating-a-personal-access-token) with `repo` scope.
+3. Create a Classic [Personal Access Token (PAT)](https://docs.github.com/en/github/authenticating-to-github/creating-a-personal-access-token) with `repo` [and `workflow`](https://github.com/peter-evans/create-pull-request/issues/3510) scopes.
 4. Logout and log back into your main user account.
 5. Add a secret to your repository containing the above PAT.
 6. As shown in the following example workflow, set the `push-to-fork` input to the full repository name of the fork.

--- a/docs/concepts-guidelines.md
+++ b/docs/concepts-guidelines.md
@@ -231,7 +231,7 @@ It will use their own fork to push code and create the pull request.
 
 1. Create a new GitHub user and login.
 2. Fork the repository that you will be creating pull requests in.
-3. Create a Classic [Personal Access Token (PAT)](https://docs.github.com/en/github/authenticating-to-github/creating-a-personal-access-token) with `repo` [and `workflow`](https://github.com/peter-evans/create-pull-request/issues/3510) scopes.
+3. Create a Classic [Personal Access Token (PAT)](https://docs.github.com/en/github/authenticating-to-github/creating-a-personal-access-token) with `repo` scope. If the upstream repository uses GitHub Actions, it's highly likely that you will also need the `workflow` scope.
 4. Logout and log back into your main user account.
 5. Add a secret to your repository containing the above PAT.
 6. As shown in the following example workflow, set the `push-to-fork` input to the full repository name of the fork.


### PR DESCRIPTION
Closes https://github.com/peter-evans/create-pull-request/issues/3510

Even if the scenario I hit this with is fairly specific, we know that if nothing else, at least _this_ action is in `.github/workflows` somewhere, and the issue is possible if not likely to trigger in all setups when they update this action's version in it.