### PR TITLE
Set title/body from commit-message if given

### DIFF
--- a/__test__/utils.unit.test.ts
+++ b/__test__/utils.unit.test.ts
@@ -37,6 +37,40 @@ describe('utils tests', () => {
     expect(array[2]).toEqual('team3')
   })
 
+  test('getTitleBodyFromCommitMessage works for single-line', async () => {
+    const {title, body} = utils.getTitleBodyFromCommitMessage(
+      'This is a commit message'
+    )
+    expect(title).toEqual('This is a commit message')
+    expect(body).toEqual('')
+  })
+
+  test('getTitleBodyFromCommitMessage works for multi-line', async () => {
+    const {title, body} = utils.getTitleBodyFromCommitMessage(
+      'This is a commit message\n' +
+        'That is not properly formatted with blank line\n' +
+        'between title and body'
+    )
+    expect(title).toEqual('This is a commit message')
+    expect(body).toEqual(
+      'That is not properly formatted with blank line\n' +
+        'between title and body'
+    )
+  })
+
+  test('getTitleBodyFromCommitMessage works for title with body', async () => {
+    const {title, body} = utils.getTitleBodyFromCommitMessage(
+      'This is a commit message\n' +
+        '\n' +
+        'That IS properly formatted with blank line\n' +
+        'between title and body'
+    )
+    expect(title).toEqual('This is a commit message')
+    expect(body).toEqual(
+      'That IS properly formatted with blank line\n' + 'between title and body'
+    )
+  })
+
   test('getRepoPath successfully returns the path to the repository', async () => {
     expect(utils.getRepoPath()).toEqual(process.env['GITHUB_WORKSPACE'])
     expect(utils.getRepoPath('foo')).toEqual(

--- a/src/main.ts
+++ b/src/main.ts
@@ -44,6 +44,18 @@ async function run(): Promise<void> {
     if (!inputs.token) {
       throw new Error(`Input 'token' not supplied. Unable to continue.`)
     }
+    if (
+      inputs.commitMessage &&
+      inputs.commitMessage !== '' &&
+      inputs.body === '' &&
+      inputs.bodyPath === ''
+    ) {
+      const {title, body} = utils.getTitleBodyFromCommitMessage(
+        inputs.commitMessage
+      )
+      inputs.title = title
+      inputs.body = body
+    }
     if (!inputs.branchToken) {
       inputs.branchToken = inputs.token
     }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -26,6 +26,18 @@ export function stripOrgPrefixFromTeams(teams: string[]): string[] {
   })
 }
 
+export function getTitleBodyFromCommitMessage(commitMessage: string): {
+  title: string
+  body: string
+} {
+  const lines = commitMessage.split('\n')
+
+  return {
+    title: lines[0] ?? '',
+    body: lines.slice(1).join('\n').trim()
+  }
+}
+
 export function getRepoPath(relativePath?: string): string {
   let githubWorkspacePath = process.env['GITHUB_WORKSPACE']
   if (!githubWorkspacePath) {


### PR DESCRIPTION
Hi there-

I'd like to set just one input to customize the commit-message, title, and body
without having to duplicate things. So here is a PR that I think does that with
a pretty simple implementation scoped to inputs parsing.

Apologies if I've missed conventions or details anywhere, just let me know.

I also have a few tangential questions that came up while doing this:

1. Requiring `../lib/utils` in the tests (vs just `../utils`) meant I had to run a `build` any time I changed something for the tests to see the change. This seems inconvenient, am I missing something?
2. The type of `body` and `bodyPath` are `string` (not `string | null`), so I'm using the `=== ''` condition to determine if they've not been set. However, a few lines below I see you were doing `if (inputs.bodyPath)`. I would think that condition can never be false if `bodyPath` is only ever a `string` -- but it seems to work? I'm not a JavaScript expert, so I may be missing something here too. Should I be doing `!inputs.body` (etc) in my own conditions?

And here is the commit message of my change with further details:

If `title`, `body`, and `body-path` are all not given, and
`commit-message` is, parse the `title` and `body` from the
'commit-message'.

A properly formatted message (title, blank line, then body) will be used
as title and body. Otherwise, the first line is used as title and the
remaining lines as body. Another valid approach could be to take all the
lines as title, or all the lines until the first blank as title, but the
former is unlikely to be the user's intention and the latter would
introduce complexity.

The parsing function was added in `utils` to facilitate testing.