### PR TITLE
docs: add workflow tip for showing message via workflow command

### DIFF
--- a/docs/examples.md
+++ b/docs/examples.md
@@ -444,7 +444,7 @@ An `on: repository_dispatch` workflow can be triggered from another workflow wit
 This is a pattern that lends itself to automated code linting and fixing. A pull request can be created to fix or modify something during an `on: pull_request` workflow. The pull request containing the fix will be raised with the original pull request as the base. This can be then be merged to update the original pull request and pass any required tests.
 
 Note that due to [token restrictions on public repository forks](https://docs.github.com/en/actions/configuring-and-managing-workflows/authenticating-with-the-github_token#permissions-for-the-github_token), workflows for this use case do not work for pull requests raised from forks.
-Private repositories can be configured to [enable workflows](https://docs.github.com/en/github/administering-a-repository/disabling-or-limiting-github-actions-for-a-repository#enabling-workflows-for-private-repository-forks) from forks to run without restriction.
+Private repositories can be configured to [enable workflows](https://docs.github.com/en/github/administering-a-repository/disabling-or-limiting-github-actions-for-a-repository#enabling-workflows-for-private-repository-forks) from forks to run without restriction. 
 
 ### autopep8
 

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -503,7 +503,7 @@ For workflows using `on: push` you may want to ignore push events for tags and o
 on:
   push:
     branches:
-      - '**'
+      - '**' 
 ```
 
 If you have a workflow that contains jobs to handle push events on branches as well as tags, you can make sure that the job where you use `create-pull-request` action only executes when `github.ref` is a branch by using an `if` condition as follows.


### PR DESCRIPTION
Closes #3624

This PR adds a workflow tip to the examples document. The example uses the `notice` workflow command to show a created pull request info.

Please feel free to give me feedback!