### PR TITLE
Fix GitHub API not providing details for existing PRs in private repos

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -1308,6 +1308,13 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
         step((generator = generator.apply(thisArg, _arguments || [])).next());
     });
 };
+var __asyncValues = (this && this.__asyncValues) || function (o) {
+    if (!Symbol.asyncIterator) throw new TypeError("Symbol.asyncIterator is not defined.");
+    var m = o[Symbol.asyncIterator], i;
+    return m ? m.call(o) : (o = typeof __values === "function" ? __values(o) : o[Symbol.iterator](), i = {}, verb("next"), verb("throw"), verb("return"), i[Symbol.asyncIterator] = function () { return this; }, i);
+    function verb(n) { i[n] = o[n] && function (v) { return new Promise(function (resolve, reject) { v = o[n](v), settle(resolve, reject, v.done, v.value); }); }; }
+    function settle(resolve, reject, d, v) { Promise.resolve(v).then(function(v) { resolve({ value: v, done: d }); }, reject); }
+};
 var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
@@ -1345,6 +1352,7 @@ class GitHubHelper {
     }
     createOrUpdate(inputs, baseRepository, headRepository) {
         return __awaiter(this, void 0, void 0, function* () {
+            var _a, e_1, _b, _c;
             const [headOwner] = headRepository.split('/');
             const headBranch = `${headOwner}:${inputs.branch}`;
             // Try to create the pull request
@@ -1377,8 +1385,37 @@ class GitHubHelper {
             // Update the pull request that exists for this branch and base
             core.info(`Fetching existing pull request`);
             const { data: pulls } = yield this.octokit.rest.pulls.list(Object.assign(Object.assign({}, this.parseRepository(baseRepository)), { state: 'open', head: headBranch, base: inputs.base }));
+            let existingPullNumber = undefined;
+            if ((pulls === null || pulls === void 0 ? void 0 : pulls.length) === 0 || pulls === null || pulls === undefined) {
+                core.error(`Failed to fetch existing pull request details through API - fetching all pull requests to manually check`);
+                try {
+                    for (var _d = true, _e = __asyncValues(this.octokit.paginate.iterator(this.octokit.rest.pulls.list, Object.assign(Object.assign({}, this.parseRepository(baseRepository)), { state: 'open', base: inputs.base }))), _f; _f = yield _e.next(), _a = _f.done, !_a; _d = true) {
+                        _c = _f.value;
+                        _d = false;
+                        const response = _c;
+                        const existingPull = response.data.find(pull => pull.head.label === headBranch);
+                        if (existingPull !== undefined) {
+                            existingPullNumber = existingPull.number;
+                            break;
+                        }
+                    }
+                }
+                catch (e_1_1) { e_1 = { error: e_1_1 }; }
+                finally {
+                    try {
+                        if (!_d && !_a && (_b = _e.return)) yield _b.call(_e);
+                    }
+                    finally { if (e_1) throw e_1.error; }
+                }
+            }
+            else {
+                existingPullNumber = pulls[0].number;
+            }
+            if (existingPullNumber === undefined) {
+                throw new Error(`A pull request already exists for ${headBranch} but couldn't acquire the pull number`);
+            }
             core.info(`Attempting update of pull request`);
-            const { data: pull } = yield this.octokit.rest.pulls.update(Object.assign(Object.assign({}, this.parseRepository(baseRepository)), { pull_number: pulls[0].number, title: inputs.title, body: inputs.body }));
+            const { data: pull } = yield this.octokit.rest.pulls.update(Object.assign(Object.assign({}, this.parseRepository(baseRepository)), { pull_number: existingPullNumber, title: inputs.title, body: inputs.body }));
             core.info(`Updated pull request #${pull.number} (${headBranch} => ${inputs.base})`);
             return {
                 number: pull.number,


### PR DESCRIPTION
This should hopefully fix #3742 - tested on a private enterprise repo

<img width="827" height="104" alt="image" src="https://github.com/user-attachments/assets/ffb9e176-e20b-4ad2-95b4-3c1c9c6d86ac" />

I did some testing to discover why this was failing, and found that the ["List pull requests" endpoint](https://docs.github.com/en/enterprise-cloud@latest/rest/pulls/pulls?apiVersion=2022-11-28#list-pull-requests) always returns an empty array if run against an enterprise owned repo when the `head` query is set - I asume this also applies to other private repos.