### PR TITLE
feat: allow branch name derivation from base branch for namespacing

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -34,7 +34,10 @@ inputs:
     description: 'Add `Signed-off-by` line by the committer at the end of the commit log message.'
     default: false
   branch:
-    description: 'The pull request branch name.'
+    description: >
+      The pull request branch name.
+      Supports the placeholder `${base}` which will be replaced with the base branch name.
+      For example, `${base}/patch` becomes `main/patch` when base is `main`.
     default: 'create-pull-request/patch'
   delete-branch:
     description: >

--- a/dist/index.js
+++ b/dist/index.js
@@ -446,6 +446,14 @@ function createPullRequest(inputs) {
             }
             // If the base is not specified it is assumed to be the working base.
             const base = inputs.base ? inputs.base : workingBase;
+            // Substitute ${base} placeholder in branch name
+            if (inputs.branch.includes('${base}')) {
+                // Sanitize base branch name for use in branch name
+                // Replace forward slashes with hyphens to avoid nested directory issues
+                const sanitizedBase = base.replace(/\//g, '-');
+                inputs.branch = inputs.branch.replace(/\$\{base\}/g, sanitizedBase);
+                core.info(`Branch name derived from base: '${inputs.branch}'`);
+            }
             // Throw an error if the base and branch are not different branches
             // of the 'origin' remote. An identically named branch in the `fork`
             // remote is perfectly fine.

--- a/src/create-pull-request.ts
+++ b/src/create-pull-request.ts
@@ -113,6 +113,16 @@ export async function createPullRequest(inputs: Inputs): Promise<void> {
     }
     // If the base is not specified it is assumed to be the working base.
     const base = inputs.base ? inputs.base : workingBase
+    
+    // Substitute ${base} placeholder in branch name
+    if (inputs.branch.includes('${base}')) {
+      // Sanitize base branch name for use in branch name
+      // Replace forward slashes with hyphens to avoid nested directory issues
+      const sanitizedBase = base.replace(/\//g, '-')
+      inputs.branch = inputs.branch.replace(/\$\{base\}/g, sanitizedBase)
+      core.info(`Branch name derived from base: '${inputs.branch}'`)
+    }
+    
     // Throw an error if the base and branch are not different branches
     // of the 'origin' remote. An identically named branch in the `fork`
     // remote is perfectly fine.


### PR DESCRIPTION
## Summary

Implements the ability to derive the target branch name from the base branch, enabling "namespacing" of generated pull requests based on their target branch.

## Changes Made

- Added support for deriving branch names from base branch references
- Enables automated code generation workflows to create PRs against multiple branches
- Allows bots to namespace pull requests based on their target branch

## Why This Change

This feature addresses the need for code generation workflows where:
- Code changes trigger automated codegen jobs
- PRs need to be opened against multiple branches
- Each PR should be namespaced to its target branch for better organization

Fixes #3668

---

**Agent:** blackbox
**Model:** blackboxai/blackbox-pro