### PR TITLE
fix: double auth with checkout v6

### DIFF
--- a/src/git-command-manager.ts
+++ b/src/git-command-manager.ts
@@ -115,6 +115,7 @@ export class GitCommandManager {
       [
         'config',
         globalConfig ? '--global' : '--local',
+        '--includes', // Detect configs from included files (e.g., checkout@v6)
         '--name-only',
         '--get-regexp',
         configKey,
@@ -212,6 +213,7 @@ export class GitCommandManager {
     const output = await this.exec([
       'config',
       '--local',
+      '--includes', // Get configs from included files (e.g., checkout@v6)
       '--get-regexp',
       configKey,
       configValue

--- a/src/git-config-helper.ts
+++ b/src/git-config-helper.ts
@@ -144,6 +144,27 @@ export class GitConfigHelper {
     ).toString('base64')
     core.setSecret(basicCredential)
     const extraheaderConfigValue = `AUTHORIZATION: basic ${basicCredential}`
+
+    // Check if the same token is already configured (e.g., by checkout@v6)
+    // If so, skip reconfiguration to avoid duplicate headers
+    if (
+      await this.git.configExists(
+        this.extraheaderConfigKey,
+        this.extraheaderConfigValueRegex
+      )
+    ) {
+      const existingValue = await this.git.getConfigValue(
+        this.extraheaderConfigKey,
+        this.extraheaderConfigValueRegex
+      )
+      if (existingValue === extraheaderConfigValue) {
+        core.info(
+          'Git credentials already configured with the same token, skipping reconfiguration'
+        )
+        return
+      }
+    }
+
     await this.setExtraheaderConfig(extraheaderConfigValue)
   }
 


### PR DESCRIPTION
   # Fix: Compatibility with actions/checkout@v6

   ## Summary

   Fixes the "Duplicate header: Authorization" error that occurs when using `actions/checkout@v6`.

   Closes #4228

   ## Problem

   After upgrading to `actions/checkout@v6`, the action fails during `git remote prune` with:
   ```
   remote: Duplicate header: "Authorization"
   fatal: unable to access '<repository URL>': The requested URL returned error: 400
   ```

   ## What Changed

   **actions/checkout@v6** now stores Git credentials in a separate file using Git's `includeIf` feature instead of directly in `.git/config` ([PR
   #2286](https://github.com/actions/checkout/pull/2286)).

   This caused `create-pull-request` to:
   - Not detect the existing credentials (was only checking `.git/config`)
   - Configure duplicate credentials
   - Result: Git sends 2 Authorization headers → HTTP 400 error

   ## Solution

   **Reuse credentials instead of reconfiguring them.**

   The fix adds:
   1. `--includes` flag to Git commands so they can see credentials from included files
   2. Check if the same token is already configured before reconfiguring
   3. If credentials exist with the same token, skip reconfiguration and reuse them

   This avoids the duplicate header problem while maintaining backward compatibility with checkout@v5.

   ## Links

   - Issue: #4228
   - Upstream change: https://github.com/actions/checkout/pull/2286
   - Checkout v6 release: https://github.com/actions/checkout/releases/tag/v6.0.0

## Extra notes
- Mostly done with Claude Code but validated by me. The first solution it proposed was to remove all the tokens then add just this token but I suggested it a simpler approach based on token idempotency. BTW Claude Code did all the issue/PR research to bring context to the changes.