### PR TITLE
Handle remote prune failures gracefully on self-hosted runners

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -458,7 +458,12 @@ function createPullRequest(inputs) {
                 // deleted after being merged or closed. Without this the push using
                 // '--force-with-lease' fails due to "stale info."
                 // https://github.com/peter-evans/create-pull-request/issues/633
-                yield git.exec(['remote', 'prune', branchRemoteName]);
+                try {
+                    yield git.exec(['remote', 'prune', branchRemoteName]);
+                }
+                catch (error) {
+                    core.warning(`Failed to prune remote '${branchRemoteName}': ${error.message}`);
+                }
             }
             core.endGroup();
             // Apply the branch suffix if set

--- a/package-lock.json
+++ b/package-lock.json
@@ -130,6 +130,7 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.24.9.tgz",
       "integrity": "sha512-5e3FI4Q3M3Pbr21+5xJwCv6ZT6KmGkI0vw3Tozy5ODAQFTIWe37iT8Cr7Ice2Ntb+M3iSKCEWMB1MBgKrW3whg==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.24.7",
@@ -1252,6 +1253,7 @@
       "resolved": "https://registry.npmjs.org/@octokit/core/-/core-6.1.6.tgz",
       "integrity": "sha512-kIU8SLQkYWGp3pVKiYzA5OSaNF5EE03P/R8zEmmrG6XwOg5oBjXyQVVIauQ0dgau4zYhpZEhJrvIYt6oM+zZZA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^5.0.0",
         "@octokit/graphql": "^8.2.2",
@@ -2478,6 +2480,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.12.1.tgz",
       "integrity": "sha512-tcpGyI9zbizT9JbV6oYE477V6mTlXvvi0T0G3SNIYE2apm/G5huBa1+K89VGeovbg+jycCrfhl3ADxErOuO6Jg==",
       "dev": true,
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2983,6 +2986,7 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001640",
         "electron-to-chromium": "^1.4.820",
@@ -3854,6 +3858,7 @@
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.57.1.tgz",
       "integrity": "sha512-ypowyDxpVSYpkXr9WPv2PAZCtNip1Mv5KTW0SCurXv/9iOpcrH9PaqUElksqEB6pChqHGDRCFTyrZlGhnLNGiA==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -4100,6 +4105,7 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -5689,6 +5695,7 @@
       "resolved": "https://registry.npmjs.org/jest/-/jest-29.7.0.tgz",
       "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@jest/core": "^29.7.0",
         "@jest/types": "^29.6.3",
@@ -7233,6 +7240,7 @@
       "integrity": "sha512-v6UNi1+3hSlVvv8fSaoUbggEM5VErKmmpGA7Pl3HF8V6uKY7rvClBOJlH6yNwQtfTueNkGVpOv/mtWL9L4bgRA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -8106,6 +8114,7 @@
       "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -8423,6 +8432,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/src/create-pull-request.ts
+++ b/src/create-pull-request.ts
@@ -127,7 +127,13 @@ export async function createPullRequest(inputs: Inputs): Promise<void> {
       // deleted after being merged or closed. Without this the push using
       // '--force-with-lease' fails due to "stale info."
       // https://github.com/peter-evans/create-pull-request/issues/633
-      await git.exec(['remote', 'prune', branchRemoteName])
+      try {
+        await git.exec(['remote', 'prune', branchRemoteName])
+      } catch (error) {
+        core.warning(
+          `Failed to prune remote '${branchRemoteName}': ${(error as Error).message}`
+        )
+      }
     }
     core.endGroup()
 


### PR DESCRIPTION
Towards https://github.com/peter-evans/create-pull-request/issues/4198

Wrap the git remote prune command in a try-catch block to prevent the action from failing if the prune operation fails. Instead, log a warning message and allow the action to continue.

Fixes edge cases where the prune command may fail on self-hosted runners but shouldn't block the pull request creation workflow.