### PR TITLE
feat: add @octokit/plugin-retry to handle retriable server errors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@octokit/core": "^6.1.6",
         "@octokit/plugin-paginate-rest": "^11.6.0",
         "@octokit/plugin-rest-endpoint-methods": "^13.5.0",
+        "@octokit/plugin-retry": "^7.2.1",
         "@octokit/plugin-throttling": "^9.6.1",
         "node-fetch-native": "^1.6.7",
         "p-limit": "^6.2.0",
@@ -130,6 +131,7 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.24.9.tgz",
       "integrity": "sha512-5e3FI4Q3M3Pbr21+5xJwCv6ZT6KmGkI0vw3Tozy5ODAQFTIWe37iT8Cr7Ice2Ntb+M3iSKCEWMB1MBgKrW3whg==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.24.7",
@@ -1252,6 +1254,7 @@
       "resolved": "https://registry.npmjs.org/@octokit/core/-/core-6.1.6.tgz",
       "integrity": "sha512-kIU8SLQkYWGp3pVKiYzA5OSaNF5EE03P/R8zEmmrG6XwOg5oBjXyQVVIauQ0dgau4zYhpZEhJrvIYt6oM+zZZA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^5.0.0",
         "@octokit/graphql": "^8.2.2",
@@ -1371,6 +1374,38 @@
       },
       "peerDependencies": {
         "@octokit/core": ">=6"
+      }
+    },
+    "node_modules/@octokit/plugin-retry": {
+      "version": "7.2.1",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-retry/-/plugin-retry-7.2.1.tgz",
+      "integrity": "sha512-wUc3gv0D6vNHpGxSaR3FlqJpTXGWgqmk607N9L3LvPL4QjaxDgX/1nY2mGpT37Khn+nlIXdljczkRnNdTTV3/A==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/request-error": "^6.1.8",
+        "@octokit/types": "^14.0.0",
+        "bottleneck": "^2.15.3"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "@octokit/core": ">=6"
+      }
+    },
+    "node_modules/@octokit/plugin-retry/node_modules/@octokit/openapi-types": {
+      "version": "25.1.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-25.1.0.tgz",
+      "integrity": "sha512-idsIggNXUKkk0+BExUn1dQ92sfysJrje03Q0bv0e+KPLrvyqZF8MnBpFz8UNfYDwB3Ie7Z0TByjWfzxt7vseaA==",
+      "license": "MIT"
+    },
+    "node_modules/@octokit/plugin-retry/node_modules/@octokit/types": {
+      "version": "14.1.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-14.1.0.tgz",
+      "integrity": "sha512-1y6DgTy8Jomcpu33N+p5w58l6xyt55Ar2I91RPiIA0xCJBXyUAhXCcmZaDWSANiha7R9a6qJJ2CRomGPZ6f46g==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/openapi-types": "^25.1.0"
       }
     },
     "node_modules/@octokit/plugin-throttling": {
@@ -2478,6 +2513,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.12.1.tgz",
       "integrity": "sha512-tcpGyI9zbizT9JbV6oYE477V6mTlXvvi0T0G3SNIYE2apm/G5huBa1+K89VGeovbg+jycCrfhl3ADxErOuO6Jg==",
       "dev": true,
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2983,6 +3019,7 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001640",
         "electron-to-chromium": "^1.4.820",
@@ -3854,6 +3891,7 @@
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.57.1.tgz",
       "integrity": "sha512-ypowyDxpVSYpkXr9WPv2PAZCtNip1Mv5KTW0SCurXv/9iOpcrH9PaqUElksqEB6pChqHGDRCFTyrZlGhnLNGiA==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -4100,6 +4138,7 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -5689,6 +5728,7 @@
       "resolved": "https://registry.npmjs.org/jest/-/jest-29.7.0.tgz",
       "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@jest/core": "^29.7.0",
         "@jest/types": "^29.6.3",
@@ -7233,6 +7273,7 @@
       "integrity": "sha512-v6UNi1+3hSlVvv8fSaoUbggEM5VErKmmpGA7Pl3HF8V6uKY7rvClBOJlH6yNwQtfTueNkGVpOv/mtWL9L4bgRA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -8106,6 +8147,7 @@
       "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -8423,6 +8465,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "@octokit/core": "^6.1.6",
     "@octokit/plugin-paginate-rest": "^11.6.0",
     "@octokit/plugin-rest-endpoint-methods": "^13.5.0",
+    "@octokit/plugin-retry": "^7.2.1",
     "@octokit/plugin-throttling": "^9.6.1",
     "node-fetch-native": "^1.6.7",
     "p-limit": "^6.2.0",

--- a/src/github-helper.ts
+++ b/src/github-helper.ts
@@ -1,7 +1,12 @@
 import * as core from '@actions/core'
 import {Inputs} from './create-pull-request'
 import {Commit, GitCommandManager} from './git-command-manager'
-import {Octokit, OctokitOptions, throttleOptions} from './octokit-client'
+import {
+  Octokit,
+  OctokitOptions,
+  retryOptions,
+  throttleOptions
+} from './octokit-client'
 import pLimit from 'p-limit'
 import * as utils from './utils'
 
@@ -52,6 +57,7 @@ export class GitHubHelper {
       options.baseUrl = 'https://api.github.com'
     }
     options.throttle = throttleOptions
+    options.retry = retryOptions
     this.octokit = new Octokit(options)
   }
 

--- a/src/octokit-client.ts
+++ b/src/octokit-client.ts
@@ -2,6 +2,7 @@ import * as core from '@actions/core'
 import {Octokit as OctokitCore} from '@octokit/core'
 import {paginateRest} from '@octokit/plugin-paginate-rest'
 import {restEndpointMethods} from '@octokit/plugin-rest-endpoint-methods'
+import {retry} from '@octokit/plugin-retry'
 import {throttling} from '@octokit/plugin-throttling'
 import {fetch} from 'node-fetch-native/proxy'
 export {RestEndpointMethodTypes} from '@octokit/plugin-rest-endpoint-methods'
@@ -11,6 +12,7 @@ export {OctokitOptions} from '@octokit/core/dist-types/types'
 export const Octokit = OctokitCore.plugin(
   paginateRest,
   restEndpointMethods,
+  retry,
   throttling,
   autoProxyAgent
 )
@@ -30,6 +32,11 @@ export const throttleOptions = {
     )
     core.warning(`Requests may be retried after ${retryAfter} seconds.`)
   }
+}
+
+export const retryOptions = {
+  // 429 is handled by the throttling plugin, so we exclude it from retry
+  doNotRetry: [400, 401, 403, 404, 410, 422, 429, 451]
 }
 
 // Octokit plugin to support the standard environment variables http_proxy, https_proxy and no_proxy


### PR DESCRIPTION
Fixes https://github.com/peter-evans/create-pull-request/issues/4294

Add the retry plugin to automatically retry requests that fail with server errors (5xx status codes). Configure the plugin to exclude 429 (rate limit) from retries since that is already handled by the throttling plugin.

- Add @octokit/plugin-retry dependency
- Register retry plugin in Octokit client
- Export retryOptions with doNotRetry list excluding 429
- Apply retryOptions in GitHubHelper constructor