### PR TITLE
fix: pin 7 unpinned action(s), extract 3 unsafe expression(s) to env vars

### DIFF
--- a/.github/workflows/automerge-dependabot.yml
+++ b/.github/workflows/automerge-dependabot.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.actor == 'dependabot[bot]'
     steps:
-      - uses: peter-evans/enable-pull-request-automerge@v3
+      - uses: peter-evans/enable-pull-request-automerge@a660677d5469627102a1c1e11409dd063606628d # v3
         with:
           token: ${{ secrets.ACTIONS_BOT_TOKEN }}
           pull-request-number: ${{ github.event.pull_request.number }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,7 +80,7 @@ jobs:
           branch: ci-test-${{ matrix.target }}-${{ github.sha }}
 
       - name: Close Pull
-        uses: peter-evans/close-pull@v3
+        uses: peter-evans/close-pull@a192af8d70f2d49c49643134605c3b73d4f80fae # v3
         with:
           pull-request-number: ${{ steps.cpr.outputs.pull-request-number }}
           comment: '[CI] test ${{ matrix.target }}'
@@ -92,7 +92,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Find Comment
-        uses: peter-evans/find-comment@v4
+        uses: peter-evans/find-comment@b30e6a3c0ed37e7c023ccd3f1db5c6c0b0c23aad # v4
         id: fc
         with:
           issue-number: ${{ github.event.number }}
@@ -101,7 +101,7 @@ jobs:
 
       - if: steps.fc.outputs.comment-id == ''
         name: Create comment
-        uses: peter-evans/create-or-update-comment@v5
+        uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5
         with:
           issue-number: ${{ github.event.number }}
           body: |
@@ -124,7 +124,7 @@ jobs:
           name: dist
           path: dist
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v8
+        uses: peter-evans/create-pull-request@c0f553fe549906ede9cf27b5156039d195d2ece0 # v8
         with:
           token: ${{ secrets.ACTIONS_BOT_TOKEN }}
           commit-message: 'build: update distribution'

--- a/.github/workflows/cpr-example-command.yml
+++ b/.github/workflows/cpr-example-command.yml
@@ -42,7 +42,7 @@ jobs:
           echo "Pull Request URL - ${{ steps.cpr.outputs.pull-request-url }}"
 
       - name: Add reaction
-        uses: peter-evans/create-or-update-comment@v5
+        uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5
         with:
           repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
           comment-id: ${{ github.event.client_payload.github.payload.comment.id }}

--- a/.github/workflows/slash-command-dispatch.yml
+++ b/.github/workflows/slash-command-dispatch.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Slash Command Dispatch
-        uses: peter-evans/slash-command-dispatch@v5
+        uses: peter-evans/slash-command-dispatch@9bdcd7914ec1b75590b790b844aa3b8eee7c683a # v5
         with:
           token: ${{ secrets.ACTIONS_BOT_TOKEN }}
           config: >

--- a/.github/workflows/update-major-version.yml
+++ b/.github/workflows/update-major-version.yml
@@ -27,6 +27,11 @@ jobs:
         git config user.name actions-bot
         git config user.email actions-bot@users.noreply.github.com
     - name: Tag new target
-      run: git tag -f ${{ github.event.inputs.main_version }} ${{ github.event.inputs.target }}
+      run: git tag -f "${INPUT_MAIN_VERSION}" "${INPUT_TARGET}"
+      env:
+        INPUT_MAIN_VERSION: ${{ github.event.inputs.main_version }}
+        INPUT_TARGET: ${{ github.event.inputs.target }}
     - name: Push new tag
-      run: git push origin ${{ github.event.inputs.main_version }} --force
+      run: git push origin "${INPUT_MAIN_VERSION}" --force
+      env:
+        INPUT_MAIN_VERSION: ${{ github.event.inputs.main_version }}


### PR DESCRIPTION
## Summary

This PR hardens your CI/CD workflows against supply chain attacks by pinning GitHub Actions to immutable commit SHAs and extracting unsafe expressions from `run:` blocks into `env:` mappings.

**A note on pinning internal/org-owned actions:** Some of the actions pinned in this PR are ones you maintain. The reason we pin these as well is that the tj-actions compromise in March 2025 and the Trivy compromise in March 2026 both worked by compromising a maintainer account and pushing malicious code to mutable tags that the organization controlled. Scoped permissions on a workflow reduce the blast radius but do not prevent the compromise - a compromised maintainer account can modify the action code itself, which then executes in every downstream workflow regardless of that workflow's permission settings. SHA pinning is the only mechanism that prevents a force-pushed tag from changing what your workflow executes.

### Fixes applied (in this PR)

| Rule | Severity | File | Description |
|------|----------|------|-------------|
| RGS-007 | medium | `automerge-dependabot.yml` | Pinned 1 action(s) to commit SHA |
| RGS-007 | medium | `ci.yml` | Pinned 4 action(s) to commit SHA |
| RGS-007 | medium | `cpr-example-command.yml` | Pinned 1 action(s) to commit SHA |
| RGS-007 | medium | `slash-command-dispatch.yml` | Pinned 1 action(s) to commit SHA |
| RGS-008 | high | `update-major-version.yml` | Extracted 3 expression(s) to env vars |

### Advisory: additional findings (manual review recommended)

| Rule | Severity | File | Description |
|------|----------|------|-------------|
| RGS-004 | high | `slash-command-dispatch.yml` | Comment-Triggered Workflow Without Author Authorization Check |
| RGS-018 | high | `update-major-version.yml` | Suspicious Payload Execution Pattern |
| RGS-019 | medium | `cpr-example-command.yml` | Step Output Interpolated in run Block |

## Why this PR

I've been scanning the top 50,000 GitHub repositories for CI/CD pipeline vulnerabilities over the last 5 weeks as part of an ongoing research effort into the supply chain attack campaign that started with tj-actions in March and has escalated through multiple phases since, where attackers compromise maintainer accounts and force-push malicious code to mutable action tags - every downstream project referencing those tags then executes the attacker's code with full access to secrets and deployment credentials.

You may notice that I have opened up a lot of PRs - don't take that as a negative. I've been working around the clock on this and monitoring all comms. It may take me an hour or two to get back to a comment you leave.

## How to verify

Every change is mechanical and preserves workflow behavior:
- **SHA pinning**: `action@v3` becomes `action@abc123 # v3` - original version preserved as comment
- **Expression extraction**: `${{ expr }}` in `run:` moves to `env:` block, referenced as `"${ENV_VAR}"` in the script
- No workflow logic, triggers, or permissions are modified

I've had 22 merges so far. I created a tool called [Runner Guard](https://github.com/Vigilant-LLC/runner-guard) to assist in my research - it does mechanical, non-AI fixes to reduce hallucinations to zero and produce consistent fixes. If you would like to scan it yourself to validate my work, feel free.

Happy to answer any questions - I'm monitoring comms on every PR.

\- Chris Nyhuis ([dagecko](https://github.com/dagecko))